### PR TITLE
feat: Avoid cli setup checks when not required

### DIFF
--- a/src/commands/tenant.command.ts
+++ b/src/commands/tenant.command.ts
@@ -112,8 +112,8 @@ export function registerTenantCommand(program: Command) {
 }
 
 async function listTenantAction(options: CmdGlobalOptions) {
+  await setupLogger(options);
   await verifyCliAvailability();
-  setupLogger(options);
 
   const config = loadConfig();
   const meshAdapterFactory = new MeshAdapterFactory(config);
@@ -130,8 +130,8 @@ async function listTenantAction(options: CmdGlobalOptions) {
 }
 
 async function listIamAction(options: CmdIamOptions) {
+  await setupLogger(options);
   await verifyCliAvailability();
-  setupLogger(options);
 
   const config = loadConfig();
   const meshAdapterFactory = new MeshAdapterFactory(config);
@@ -151,8 +151,8 @@ async function listIamAction(options: CmdIamOptions) {
 }
 
 export async function listTenantsCostAction(options: CmdListCostsOptions) {
+  await setupLogger(options);
   await verifyCliAvailability();
-  setupLogger(options);
 
   const config = loadConfig();
   const meshAdapterFactory = new MeshAdapterFactory(config);
@@ -183,8 +183,8 @@ export async function listTenantsCostAction(options: CmdListCostsOptions) {
 }
 
 async function analyzeTagsAction(options: CmdAnalyzeTagsOptions) {
+  await setupLogger(options);
   await verifyCliAvailability();
-  setupLogger(options);
 
   const config = loadConfig();
   const meshAdapterFactory = new MeshAdapterFactory(config);

--- a/src/commands/tenant.command.ts
+++ b/src/commands/tenant.command.ts
@@ -10,6 +10,7 @@ import { TenantIamPresenterFactory } from "../presentation/tenant-iam-presenter-
 import { CLICommand, loadConfig } from "../config/config.model.ts";
 import { isatty } from "./tty.ts";
 import { MeshTableFactory } from "../presentation/mesh-table-factory.ts";
+import { verifyCliAvailability } from "../init.ts";
 
 interface CmdListCostsOptions extends CmdGlobalOptions {
   from: string;
@@ -111,6 +112,7 @@ export function registerTenantCommand(program: Command) {
 }
 
 async function listTenantAction(options: CmdGlobalOptions) {
+  await verifyCliAvailability();
   setupLogger(options);
 
   const config = loadConfig();
@@ -128,6 +130,7 @@ async function listTenantAction(options: CmdGlobalOptions) {
 }
 
 async function listIamAction(options: CmdIamOptions) {
+  await verifyCliAvailability();
   setupLogger(options);
 
   const config = loadConfig();
@@ -148,6 +151,7 @@ async function listIamAction(options: CmdIamOptions) {
 }
 
 export async function listTenantsCostAction(options: CmdListCostsOptions) {
+  await verifyCliAvailability();
   setupLogger(options);
 
   const config = loadConfig();
@@ -179,6 +183,7 @@ export async function listTenantsCostAction(options: CmdListCostsOptions) {
 }
 
 async function analyzeTagsAction(options: CmdAnalyzeTagsOptions) {
+  await verifyCliAvailability();
   setupLogger(options);
 
   const config = loadConfig();

--- a/src/init.ts
+++ b/src/init.ts
@@ -134,14 +134,20 @@ export async function verifyCliAvailability() {
   // we gain from this is significant and perceivable
   const verifications: Promise<void>[] = [];
   for (const platform in MeshPlatform) {
-    const promise = verifyConnectedCliInstalled(config, platform as MeshPlatform);
+    const promise = verifyConnectedCliInstalled(
+      config,
+      platform as MeshPlatform,
+    );
     verifications.push(promise);
   }
 
   await Promise.all(verifications);
 }
 
-async function verifyConnectedCliInstalled(config :Config, platform: MeshPlatform) {
+async function verifyConnectedCliInstalled(
+  config: Config,
+  platform: MeshPlatform,
+) {
   const cmd = PlatformCommand[platform];
   if (config.connected[platform] && await !checkCliInstalled(cmd)) {
     throw new MeshError(

--- a/src/process/shell-runner.ts
+++ b/src/process/shell-runner.ts
@@ -3,7 +3,6 @@ import { ShellOutput } from "./shell-output.ts";
 import { IShellRunner } from "./shell-runner.interface.ts";
 
 export class ShellRunner implements IShellRunner {
-
   public async run(commandStr: string): Promise<ShellOutput> {
     const commands = commandStr.split(" ");
 
@@ -19,7 +18,6 @@ export class ShellRunner implements IShellRunner {
     const rawOutput = await p.output();
     const rawError = await p.stderrOutput();
     const { code } = await p.status();
-
 
     log.debug(`Exit code for running '${commandStr}' is ${code}`);
 

--- a/src/process/shell-runner.ts
+++ b/src/process/shell-runner.ts
@@ -1,9 +1,13 @@
+import { log } from "../deps.ts";
 import { ShellOutput } from "./shell-output.ts";
 import { IShellRunner } from "./shell-runner.interface.ts";
 
 export class ShellRunner implements IShellRunner {
+
   public async run(commandStr: string): Promise<ShellOutput> {
     const commands = commandStr.split(" ");
+
+    log.debug(`ShellRunner running '${commandStr}'`);
 
     const p = Deno.run({
       cmd: commands,
@@ -15,6 +19,9 @@ export class ShellRunner implements IShellRunner {
     const rawOutput = await p.output();
     const rawError = await p.stderrOutput();
     const { code } = await p.status();
+
+
+    log.debug(`Exit code for running '${commandStr}' is ${code}`);
 
     return {
       code: code,


### PR DESCRIPTION
In order to optimize startup time, especially when only issuing a non
cloud-cli required command, collie now only checks cloud cli configuration
when required.

Should mitigate or at least lessens @JohannesRudolph startup time issue.