### PR TITLE
fix: use azure subscription id instead of name to prevent word-splitting

### DIFF
--- a/src/azure/basic-azure-cli-facade.ts
+++ b/src/azure/basic-azure-cli-facade.ts
@@ -171,7 +171,7 @@ export class BasicAzureCliFacade implements AzureCliFacade {
     subscription: Subscription,
   ): Promise<RoleAssignment[]> {
     const cmd =
-      `az role assignment list --subscription ${subscription.name} --include-inherited --all --output json`;
+      `az role assignment list --subscription ${subscription.id} --include-inherited --all --output json`;
 
     const result = await this.shellRunner.run(cmd);
     this.checkForErrors(result);


### PR DESCRIPTION
fixes #76

I wonder though if a better fix would be to change the `ShellRunner` interface to take a `string[]` for commands instead of the somewhat dangerous `cmdString.split(" ")` in there? 