### PR TITLE
Feature/add windows support

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -108,7 +108,7 @@ curl -sf -L https://raw.githubusercontent.com/meshcloud/collie-cli/main/install.
 
 **Windows**
 
-Just copy the content of [`install.ps1`](https://github.com/meshcloud/collie-cli/blob/develop/install.ps1) and run it in your PowerShell console.
+Simply copy the content of [`install.ps1`](https://github.com/meshcloud/collie-cli/blob/develop/install.ps1) and run it in your PowerShell console.
 
 ## 👋 Need help or have feedback?
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -108,9 +108,7 @@ curl -sf -L https://raw.githubusercontent.com/meshcloud/collie-cli/main/install.
 
 **Windows**
 
-We sadly do not support Windows at the moment. Follow
-[this issue](https://github.com/meshcloud/collie-cli/issues/2) to get updated on
-the progress of Collie for Windows.
+Just copy the content of [`install.ps1`](https://github.com/meshcloud/collie-cli/blob/develop/install.ps1) and run it in your PowerShell console.
 
 ## 👋 Need help or have feedback?
 

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -55,13 +55,14 @@ jobs:
         event: push
         path: bin/
 
-    - name: zip-artifacts
+    - name: preparing-artifacts
       shell: bash
       run: |
-        mkdir bin/gz
-        cd bin/collie
-        tar -czvf ../gz/collie-x86_64-apple-darwin.tar.gz collie-x86_64-apple-darwin
-        tar -czvf ../gz/collie-x86_64-unknown-linux-gnu.tar.gz collie-x86_64-unknown-linux-gnu
+        mkdir bin/artifacts
+        cd bin/collie/unix
+        tar -czvf ../../artifacts/collie-x86_64-apple-darwin.tar.gz collie-x86_64-apple-darwin
+        tar -czvf ../../artifacts/collie-x86_64-unknown-linux-gnu.tar.gz collie-x86_64-unknown-linux-gnu
+        cp bin/collie/windows/* bin/artifacts
 
     - name: build-changelog
       id: build_changelog
@@ -75,7 +76,7 @@ jobs:
     - name: create-release
       uses: ncipollo/release-action@v1
       with:
-        artifacts: bin/gz/*
+        artifacts: bin/artifacts/*
         body: ${{ steps.github_release.outputs.changelog }}
         token: ${{ secrets.GITHUB_TOKEN }}
         tag: ${{ steps.version.outputs.version }}

--- a/build.sh
+++ b/build.sh
@@ -6,25 +6,23 @@ cli_name="collie"
 
 deno_flags="--unstable --allow-read --allow-write --allow-env --allow-run"
 
-mkdir -p bin
+mkdir -p bin/unix bin/windows
 
-compile(){
+compile_unix(){
   target="$1"
 
-  deno compile $deno_flags --target "$target" --output "./bin/$cli_name-$target" src/main.ts
+  deno compile $deno_flags --target "$target" --output "./bin/unix/$cli_name-$target" src/main.ts
+}
+
+compile_windows(){
+  target="$1"
+
+  deno compile $deno_flags --target "$target" --output "./bin/windows/$cli_name-$target" src/main.ts
+ 
 }
 
 deno test $deno_flags
 
-compile "x86_64-unknown-linux-gnu"
-compile "x86_64-apple-darwin"
-#compile "x86_64-pc-windows-msvc"
-
-# first grep filters for the first line of the output "deno 1.8.1 (release, x86_64-apple-darwin)"
-# second grep extracts the architecture string, but can't get rid of the trailing ): "x86_64-apple-darwin)"
-# sed then removes the last trailing character: "x86_64-apple-darwin"
-arch=$(deno --version | grep deno | grep -o "[a-z0-9_-]*)" | sed 's/.$//')
-
-echo "currently running on $arch, creating symlink at ./bin/$cli_name"
-ln -fs "./$cli_name-$arch" "./bin/$cli_name"
-chmod +x "./bin/$cli_name"
+compile_unix "x86_64-unknown-linux-gnu"
+compile_unix "x86_64-apple-darwin"
+compile_windows "x86_64-pc-windows-msvc"

--- a/install.ps1
+++ b/install.ps1
@@ -1,6 +1,6 @@
 $url=(Invoke-WebRequest -Uri https://api.github.com/repos/meshcloud/collie-cli/releases/latest | Select-String -Pattern '.*\"browser_download_url\":\"(.*windows-msvc.exe).*' | ForEach-Object {($_.matches.groups[1]).Value})
 
 New-Item -ItemType directory -Path "${HOME}\collie-cli"
-Invoke-WebRequest -Uri $url -OutFile "${HOME}\collie-cli\collie.exe"
+Invoke-WebRequest -Uri $url -OutFile "${HOME}\collie-cli\collie"
 
-Write-Host "Please add ${HOME}\collie-cli\collie.exe to your path environemnt variable."
+Write-Host "Please add ${HOME}\collie-cli\ to your path environemnt variable."

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,6 @@
+$url=(Invoke-WebRequest -Uri https://api.github.com/repos/meshcloud/collie-cli/releases/latest | Select-String -Pattern '.*\"browser_download_url\":\"(.*windows-msvc.exe).*' | ForEach-Object {($_.matches.groups[1]).Value})
+
+New-Item -ItemType directory -Path "${HOME}\collie-cli"
+Invoke-WebRequest -Uri $url -OutFile "${HOME}\collie-cli\collie.exe"
+
+Write-Host "Please add ${HOME}\collie-cli\collie.exe to your path environemnt variable."

--- a/install.sh
+++ b/install.sh
@@ -20,7 +20,7 @@ case "$(uname -s)" in
      name="collie-x86_64-unknown-linux-gnu"
      ;;
    CYGWIN*|MINGW32*|MSYS*|MINGW*)
-     echo 'Collie currently does not support Windows. Please have a look at https://github.com/meshcloud/collie-cli/issues/2 to follow progress.'
+     echo 'Please use install.ps1 script. See readme for more information.'
      exit 1
      ;;
    *)

--- a/install.sh
+++ b/install.sh
@@ -20,7 +20,7 @@ case "$(uname -s)" in
      name="collie-x86_64-unknown-linux-gnu"
      ;;
    CYGWIN*|MINGW32*|MSYS*|MINGW*)
-     echo 'Please use install.ps1 script. See readme for more information.'
+     echo 'Please execute the install.ps1 script as mentioned in our README. Go to https://github.com/meshcloud/collie-cli#-install-and-usage'
      exit 1
      ;;
    *)

--- a/src/commands/init-commands.ts
+++ b/src/commands/init-commands.ts
@@ -12,6 +12,10 @@ import { VERSION } from "../config/version.ts";
 export function initCommands(): Command {
   const program = new Command()
     .name(CLICommand)
+    .help({
+      // The darkblue of Cliffy doesn't look great on the blue of PowerShell.
+      colors: Deno.build.os !== "windows",
+    })
     .version(VERSION)
     .type("output", OutputFormatType)
     .option(
@@ -34,7 +38,7 @@ export function initCommands(): Command {
         global: true,
       },
     )
-    .description(`${CLIName} CLI - Herd your cloud 🐑 environments with Collie`);
+    .description(`${CLIName} CLI - Herd your cloud environments with Collie`);
 
   registerConfigCmd(program);
   registerTenantCommand(program);

--- a/src/commands/init-commands.ts
+++ b/src/commands/init-commands.ts
@@ -8,13 +8,14 @@ import { registerTenantCommand } from "./tenant.command.ts";
 import { CLICommand, CLIName } from "../config/config.model.ts";
 import { registerCreateIssueCommand } from "./create-issue.command.ts";
 import { VERSION } from "../config/version.ts";
+import { isWindows } from "../os.ts";
 
 export function initCommands(): Command {
   const program = new Command()
     .name(CLICommand)
     .help({
       // The darkblue of Cliffy doesn't look great on the blue of PowerShell.
-      colors: Deno.build.os !== "windows",
+      colors: !isWindows,
     })
     .version(VERSION)
     .type("output", OutputFormatType)

--- a/src/commands/io.ts
+++ b/src/commands/io.ts
@@ -1,5 +1,3 @@
-import { readLines } from "../deps.ts";
-
 export function writeFile(path: string, text: string) {
   const encoder = new TextEncoder();
   const data = encoder.encode(text);
@@ -9,13 +7,4 @@ export function writeFile(path: string, text: string) {
 export function readFile(path: string): string {
   const decoder = new TextDecoder();
   return decoder.decode(Deno.readFileSync(path));
-}
-
-export async function askYesNo(question: string): Promise<boolean> {
-  console.log(`${question} [y,N]:`);
-
-  for await (const line of readLines(Deno.stdin)) {
-    return line.toLowerCase() === "y";
-  }
-  return false;
 }

--- a/src/config/config.model.ts
+++ b/src/config/config.model.ts
@@ -51,7 +51,7 @@ export const emptyConfig: Config = {
 
 function getConfigPath(): string {
   const path = join(".config", "collie-cli");
-  var home = "";
+  let home = "";
   if (os.default.platform() === "windows") {
     home = Deno.env.get("APPDATA") || "";
   } else {

--- a/src/config/config.model.ts
+++ b/src/config/config.model.ts
@@ -1,6 +1,7 @@
 import { readFile, writeFile } from "../commands/io.ts";
-import { dirname, ensureDir, join, os } from "../deps.ts";
+import { dirname, ensureDir, join } from "../deps.ts";
 import { parseJsonWithLog } from "../json.ts";
+import { isWindows } from "../os.ts";
 
 export const configPath = getConfigPath();
 export const configFilePath = join(configPath, "config.json");
@@ -52,7 +53,7 @@ export const emptyConfig: Config = {
 function getConfigPath(): string {
   const path = join(".config", "collie-cli");
   let home = "";
-  if (os.default.platform() === "windows") {
+  if (isWindows) {
     home = Deno.env.get("APPDATA") || "";
   } else {
     home = Deno.env.get("HOME") || "";

--- a/src/config/config.model.ts
+++ b/src/config/config.model.ts
@@ -1,9 +1,9 @@
 import { readFile, writeFile } from "../commands/io.ts";
-import { dirname, ensureDir, os } from "../deps.ts";
+import { dirname, ensureDir, join, os } from "../deps.ts";
 import { parseJsonWithLog } from "../json.ts";
 
 export const configPath = getConfigPath();
-export const configFilePath = configPath + "/config.json";
+export const configFilePath = join(configPath, "config.json");
 // Use the CLI Name when mentioning it somewhere in a sentence, e.g.: Have fun using ${CLIName}!
 export const CLIName = "Collie";
 // Use the CLI Command when mentioning it as a command to run, e.g.: Please run "${CLICommand} -h" to see more.
@@ -50,11 +50,14 @@ export const emptyConfig: Config = {
 };
 
 function getConfigPath(): string {
+  const path = join(".config", "collie-cli");
+  var home = "";
   if (os.default.platform() === "windows") {
-    return Deno.env.get("APPDATA") + "/.config/collie-cli";
+    home = Deno.env.get("APPDATA") || "";
   } else {
-    return Deno.env.get("HOME") + "/.config/collie-cli";
+    home = Deno.env.get("HOME") || "";
   }
+  return join(home, path);
 }
 
 export function loadConfig(): Config {

--- a/src/config/config.model.ts
+++ b/src/config/config.model.ts
@@ -51,7 +51,7 @@ export const emptyConfig: Config = {
 
 function getConfigPath(): string {
   if (os.default.platform() === "windows") {
-    return Deno.env.get("%APPDATA%") + "/.config/collie-cli";
+    return Deno.env.get("APPDATA") + "/.config/collie-cli";
   } else {
     return Deno.env.get("HOME") + "/.config/collie-cli";
   }

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -14,7 +14,7 @@ export {
   exists,
   existsSync,
 } from "https://deno.land/std@0.99.0/fs/mod.ts";
-export { dirname } from "https://deno.land/std@0.99.0/path/mod.ts";
+export { dirname, join } from "https://deno.land/std@0.99.0/path/mod.ts";
 export {
   bold,
   brightBlue,

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -46,7 +46,6 @@ export { Confirm } from "https://deno.land/x/cliffy@v0.19.2/prompt/mod.ts";
 // other
 export * as Progress from "https://deno.land/x/progress@v1.2.3/mod.ts";
 export { Big } from "https://deno.land/x/math@v1.1.0/mod.ts";
-export * as os from "https://deno.land/x/dos@v0.11.0/mod.ts";
 export { writeCSV } from "https://deno.land/x/csv@v0.5.1/mod.ts";
 export { moment } from "https://deno.land/x/deno_moment@v1.1.2/mod.ts";
 export { open } from "https://deno.land/x/opener@v1.0.1/mod.ts";

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,5 +1,4 @@
 import { CliDetector } from "./cli-detector.ts";
-import { askYesNo } from "./commands/io.ts";
 import {
   CLICommand,
   CLIName,
@@ -8,7 +7,7 @@ import {
   loadConfig,
   writeConfig,
 } from "./config/config.model.ts";
-import { exists, log } from "./deps.ts";
+import { Confirm, exists, log } from "./deps.ts";
 import { MeshError } from "./errors.ts";
 import { MeshPlatform } from "./mesh/mesh-tenant.model.ts";
 
@@ -64,7 +63,7 @@ async function checkIfConfigExists() {
         platforms.push(val);
       }
     });
-    const answer = await askYesNo(
+    const answer: boolean = await Confirm.prompt(
       `I see you already have these cloud CLIs installed: ${
         platforms.join(", ")
       }.\nDo you want to connect these to ${CLIName}?`,

--- a/src/mesh/mesh-adapter.factory.ts
+++ b/src/mesh/mesh-adapter.factory.ts
@@ -21,6 +21,7 @@ import { AzureCliFacade } from "../azure/azure-cli-facade.ts";
 import { StatsMeshAdapterDecorator } from "./stats-mesh-adapter-decorator.ts";
 import { MeshPlatform } from "./mesh-tenant.model.ts";
 import { QueryStatistics } from "./query-statistics.ts";
+import { isWindows } from "../os.ts";
 
 /**
  * Should consume the cli configuration in order to build the
@@ -39,7 +40,7 @@ export class MeshAdapterFactory {
 
     if (options.verbose) {
       shellRunner = new VerboseShellRunner(shellRunner);
-    } else if (isatty && Deno.build.os !== "windows") {
+    } else if (isatty && !isWindows) {
       shellRunner = new LoaderShellRunner(shellRunner, new TTY());
     }
 

--- a/src/mesh/mesh-adapter.factory.ts
+++ b/src/mesh/mesh-adapter.factory.ts
@@ -39,9 +39,10 @@ export class MeshAdapterFactory {
 
     if (options.verbose) {
       shellRunner = new VerboseShellRunner(shellRunner);
-    } else if (isatty) {
+    } else if (isatty && Deno.build.os !== "windows") {
       shellRunner = new LoaderShellRunner(shellRunner, new TTY());
     }
+
     const timeWindowCalc = new TimeWindowCalculator();
     const adapters: MeshAdapter[] = [];
 

--- a/src/os.ts
+++ b/src/os.ts
@@ -1,0 +1,1 @@
+export const isWindows = Deno.build.os === "windows";

--- a/src/presentation/mesh-table-factory.ts
+++ b/src/presentation/mesh-table-factory.ts
@@ -1,3 +1,4 @@
+import { os } from "../deps.ts";
 import { MeshTable } from "./mesh-table.ts";
 import { NoTtyMeshTable } from "./no-tty-mesh-table.ts";
 import { TtyMeshTable } from "./tty-mesh-table.ts";
@@ -9,7 +10,8 @@ export class MeshTableFactory {
   }
 
   buildMeshTable(): MeshTable {
-    if (this.isatty) {
+    if (this.isatty && (os.default.platform() !== "windows")) {
+      // there are output issues with borders in windows terminal
       return new TtyMeshTable();
     } else {
       return new NoTtyMeshTable();

--- a/src/presentation/mesh-table-factory.ts
+++ b/src/presentation/mesh-table-factory.ts
@@ -10,7 +10,7 @@ export class MeshTableFactory {
   }
 
   buildMeshTable(): MeshTable {
-    if (this.isatty && (os.default.platform() !== "windows")) {
+    if (this.isatty && os.default.platform() !== "windows") {
       // there are output issues with borders in windows terminal
       return new TtyMeshTable();
     } else {

--- a/src/presentation/mesh-table-factory.ts
+++ b/src/presentation/mesh-table-factory.ts
@@ -1,7 +1,7 @@
-import { os } from "../deps.ts";
 import { MeshTable } from "./mesh-table.ts";
 import { NoTtyMeshTable } from "./no-tty-mesh-table.ts";
 import { TtyMeshTable } from "./tty-mesh-table.ts";
+import { isWindows } from "../os.ts";
 
 export class MeshTableFactory {
   constructor(
@@ -10,7 +10,7 @@ export class MeshTableFactory {
   }
 
   buildMeshTable(): MeshTable {
-    if (this.isatty && os.default.platform() !== "windows") {
+    if (this.isatty && !isWindows) {
       // there are output issues with borders in windows terminal
       return new TtyMeshTable();
     } else {

--- a/src/presentation/mesh-table.ts
+++ b/src/presentation/mesh-table.ts
@@ -1,6 +1,7 @@
 import { MeshTag } from "../mesh/mesh-tenant.model.ts";
 import { QueryStatistics } from "../mesh/query-statistics.ts";
 import { dim, Table, yellow } from "../deps.ts";
+import { CLICommand } from "../config/config.model.ts";
 
 export abstract class TableGenerator {
   abstract getColumns(): string[];
@@ -21,8 +22,29 @@ export abstract class TableGenerator {
   }
 }
 
-export interface MeshTable {
-  draw(generator: TableGenerator, stats: QueryStatistics | null): void;
+export abstract class MeshTable {
+  abstract draw(generator: TableGenerator, stats: QueryStatistics | null): void;
+
+  protected formatStats(stats: QueryStatistics): string {
+    const summary: string[] = [];
+
+    if (stats.duration["cache"]) {
+      summary.push(
+        `Loaded from cache in ${stats.duration.cache}ms. See "${CLICommand} cache" for details.`,
+      );
+    }
+
+    const cloudstats = Object
+      .entries(stats.duration)
+      .filter(([cloud]) => cloud !== "cache")
+      .map(([cloud, d]) => `${cloud}: ${(d || 0) / 1000}s`);
+
+    if (cloudstats.length) {
+      summary.push(`Queried from cloud - ${cloudstats.join(", ")}.`);
+    }
+
+    return summary.join(" ");
+  }
 }
 
 export class MeshTableTag implements MeshTag {

--- a/src/presentation/no-tty-mesh-table.ts
+++ b/src/presentation/no-tty-mesh-table.ts
@@ -1,9 +1,10 @@
 import { log, Table } from "../deps.ts";
 import { bold } from "../deps.ts";
 import { MeshTable, TableGenerator } from "./mesh-table.ts";
+import { QueryStatistics } from "../mesh/query-statistics.ts";
 
-export class NoTtyMeshTable implements MeshTable {
-  draw(generator: TableGenerator): void {
+export class NoTtyMeshTable extends MeshTable {
+  draw(generator: TableGenerator, stats: QueryStatistics | null): void {
     const rows = generator.getRows();
 
     if (rows.length === 0) {
@@ -16,5 +17,11 @@ export class NoTtyMeshTable implements MeshTable {
       .header(generator.getColumns().map((value) => bold(value)))
       .body(rows)
       .render();
+
+    if (stats) {
+      console.log(
+        this.formatStats(stats),
+      );
+    }
   }
 }

--- a/src/presentation/tty-mesh-table.ts
+++ b/src/presentation/tty-mesh-table.ts
@@ -1,10 +1,9 @@
-import { CLICommand } from "../config/config.model.ts";
 import { brightBlue, log, Table } from "../deps.ts";
 import { bold, dim, italic } from "../deps.ts";
 import { QueryStatistics } from "../mesh/query-statistics.ts";
 import { MeshTable, TableGenerator } from "./mesh-table.ts";
 
-export class TtyMeshTable implements MeshTable {
+export class TtyMeshTable extends MeshTable {
   draw(generator: TableGenerator, stats: QueryStatistics | null): void {
     const rows = generator.getRows();
 
@@ -32,26 +31,5 @@ export class TtyMeshTable implements MeshTable {
         dim(italic(this.formatStats(stats))),
       );
     }
-  }
-
-  formatStats(stats: QueryStatistics): string {
-    const summary: string[] = [];
-
-    if (stats.duration["cache"]) {
-      summary.push(
-        `Loaded from cache in ${stats.duration.cache}ms. See "${CLICommand} cache" for details.`,
-      );
-    }
-
-    const cloudstats = Object
-      .entries(stats.duration)
-      .filter(([cloud]) => cloud !== "cache")
-      .map(([cloud, d]) => `${cloud}: ${(d || 0) / 1000}s`);
-
-    if (cloudstats.length) {
-      summary.push(`Queried from cloud - ${cloudstats.join(", ")}.`);
-    }
-
-    return summary.join(" ");
   }
 }

--- a/src/process/shell-runner.ts
+++ b/src/process/shell-runner.ts
@@ -1,12 +1,13 @@
 import { log } from "../deps.ts";
 import { ShellOutput } from "./shell-output.ts";
 import { IShellRunner } from "./shell-runner.interface.ts";
+import { isWindows } from "../os.ts";
 
 export class ShellRunner implements IShellRunner {
   public async run(commandStr: string): Promise<ShellOutput> {
     // For Windows machines, we need to prepend cmd /c as it allows you to call internal and external CMD commands.
     // For more info: https://stackoverflow.com/a/62031448
-    if (Deno.build.os === "windows") {
+    if (isWindows) {
       commandStr = "cmd /c " + commandStr;
     }
 

--- a/src/process/shell-runner.ts
+++ b/src/process/shell-runner.ts
@@ -4,8 +4,13 @@ import { IShellRunner } from "./shell-runner.interface.ts";
 
 export class ShellRunner implements IShellRunner {
   public async run(commandStr: string): Promise<ShellOutput> {
-    const commands = commandStr.split(" ");
+    // For Windows machines, we need to prepend cmd /c as it allows you to call internal and external CMD commands.
+    // For more info: https://stackoverflow.com/a/62031448
+    if (Deno.build.os === "windows") {
+      commandStr = "cmd /c " + commandStr;
+    }
 
+    const commands = commandStr.split(" ");
     log.debug(`ShellRunner running '${commandStr}'`);
 
     const p = Deno.run({


### PR DESCRIPTION
For Windows:
- Save collie config in `C:\Users\<<username>>\AppData\Roaming\.config\collie-cli\`
- Disable table border because it creates weird ouput
- Create Windows artifact in build job
- upload windows artifact to release artifacts
- add install script for Windows

Close #2 