### PR TITLE
fix: Does not print error msg when SIGTERM or SIGINT

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,12 @@ try {
   Deno.exit(1);
 }
 
+// We must detect if a SIGINT or SIGTERM was raised in order to swallow potential
+// error messages.
+let isTerminated = false;
+Deno.signal(Deno.Signal.SIGINT).then(() => isTerminated = true);
+Deno.signal(Deno.Signal.SIGTERM).then(() => isTerminated = true);
+
 // Run the main program with error handling.
 try {
   const hasArgs = Deno.args.length > 0;
@@ -23,6 +29,10 @@ try {
   }
   await program.parse(Deno.args);
 } catch (e) {
+  if (isTerminated) {
+    Deno.exit(1);
+  }
+
   if (e instanceof Error) {
     console.error(red(e.stack || ""));
   }

--- a/src/process/loader-shell-runner.ts
+++ b/src/process/loader-shell-runner.ts
@@ -43,11 +43,6 @@ export class LoaderShellRunner implements IShellRunner {
     let i = 0;
     const loader = "|/-\\";
 
-    console.log(
-      brightBlue(loader[i]) + " " + bold(this.trimCommandStr(commandStr)),
-    );
-
-    this.tty.goUp(1);
     this.interval = setInterval(() => {
       this.tty.clearLine();
       const pos = i % loader.length;
@@ -82,9 +77,9 @@ export class LoaderShellRunner implements IShellRunner {
   private hideCursor() {
     // Setup a watch for interrupt signals to display the cursor again in case of SIGINT or SIGTERM
     this.sigInt = Deno.signal(Deno.Signal.SIGINT);
-    this.sigInt!.then(() => this.showCursor());
+    this.sigInt!.then(() => this.forceStopLoading());
     this.sigTerm = Deno.signal(Deno.Signal.SIGTERM);
-    this.sigTerm!.then(() => this.showCursor());
+    this.sigTerm!.then(() => this.forceStopLoading());
 
     this.tty.hideCursor();
   }


### PR DESCRIPTION
Supresses error messages from failed JSON parsing when a
SIGINT or SIGTERM was send to the clouds cli child processes.

fix #81