### PR TITLE
chore: Improves release workflow

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -2,83 +2,74 @@ name: releases
 
 on:
   push:
-    branches: ["main"]
-
+    branches: ["develop"]
+    tags:
+      - "v*"
 
 jobs:
-
   create-release:
     runs-on: ubuntu-latest
     steps:
+      - name: Merge develop -> main
+        uses: actions/checkout@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git fetch origin main
+          git fetch origin develop
+          git checkout main
+          git merge develop --ff-only
+          git push origin main
 
-    - name: checkout-main
-      uses: actions/checkout@v1
-      with:
-        ref: main
-        fetch-depth: 0
+      - name: new-version
+        id: version
+        shell: bash
+        run: |
+          version=$(git describe --tags `git rev-list --tags --max-count=1` --always)
+          echo "::set-output name=old-version::$(echo "${version}")"
+          if [[ ! "$version" =~ ^v.*$ ]]
+          then
+            echo "::set-output name=version::$(echo "v0.1.0")"
+            exit 0
+          fi
+          breaking=$(echo ${version/v/''} | cut -d'.' -f1)
+          minor=$(($(echo ${version/v/''} | cut -d'.' -f2) + 1))
+          patch=$(echo ${version/v/''} | cut -d'.' -f3)
+          echo "::set-output name=version::$(echo "v${breaking}.${minor}.${patch}")"
 
-    - name: new-version
-      id: version
-      shell: bash
-      run: |
-        version=$(git describe --tags `git rev-list --tags --max-count=1` --always)
-        echo "::set-output name=old-version::$(echo "${version}")"
-        if [[ ! "$version" =~ ^v.*$ ]]
-        then
-          echo "::set-output name=version::$(echo "v0.1.0")"
-          exit 0
-        fi
-        breaking=$(echo ${version/v/''} | cut -d'.' -f1)
-        minor=$(($(echo ${version/v/''} | cut -d'.' -f2) + 1))
-        patch=$(echo ${version/v/''} | cut -d'.' -f3)
-        echo "::set-output name=version::$(echo "v${breaking}.${minor}.${patch}")"
+      - name: download-artifact
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          github_token: ${{secrets.GITHUB_TOKEN}}
+          workflow: build.yml
+          workflow_conclusion: success
+          branch: develop
+          event: push
+          path: bin/
 
-    - name: create-tag
-      uses: actions/github-script@v3
-      with:
-        github-token: ${{ github.token }}
-        script: |
-          github.git.createRef({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            ref: "refs/tags/${{ steps.version.outputs.version }}",
-            sha: context.sha
-          })
-    
-    - name: download-artifact
-      uses: dawidd6/action-download-artifact@v2
-      with:
-        github_token: ${{secrets.GITHUB_TOKEN}}
-        workflow: build.yml
-        workflow_conclusion: success
-        branch: develop
-        event: push
-        path: bin/
+      - name: preparing-artifacts
+        shell: bash
+        run: |
+          mkdir bin/artifacts
+          cd bin/collie/unix
+          tar -czvf ../../artifacts/collie-x86_64-apple-darwin.tar.gz collie-x86_64-apple-darwin
+          tar -czvf ../../artifacts/collie-x86_64-unknown-linux-gnu.tar.gz collie-x86_64-unknown-linux-gnu
+          cd ../../..
+          cp -a bin/collie/windows/. bin/artifacts
 
-    - name: preparing-artifacts
-      shell: bash
-      run: |
-        mkdir bin/artifacts
-        cd bin/collie/unix
-        tar -czvf ../../artifacts/collie-x86_64-apple-darwin.tar.gz collie-x86_64-apple-darwin
-        tar -czvf ../../artifacts/collie-x86_64-unknown-linux-gnu.tar.gz collie-x86_64-unknown-linux-gnu
-        cd ../../..
-        cp -a bin/collie/windows/. bin/artifacts
+      - name: build-changelog
+        id: build_changelog
+        uses: mikepenz/release-changelog-builder-action@v1.8.2
+        with:
+          fromTag: ${{ steps.version.outputs.old-version }}
+          toTag: ${{ steps.version.outputs.version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: build-changelog
-      id: build_changelog
-      uses: mikepenz/release-changelog-builder-action@v1.8.2
-      with:
-        fromTag: ${{ steps.version.outputs.old-version }}
-        toTag: ${{ steps.version.outputs.version }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    
-    - name: create-release
-      uses: ncipollo/release-action@v1
-      with:
-        artifacts: bin/artifacts/*
-        body: ${{ steps.github_release.outputs.changelog }}
-        token: ${{ secrets.GITHUB_TOKEN }}
-        tag: ${{ steps.version.outputs.version }}
-        
+      - name: create-release
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: bin/artifacts/*
+          body: ${{ steps.github_release.outputs.changelog }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ steps.version.outputs.version }}


### PR DESCRIPTION
Avoids the change of history by modifying the release workflow.

Its now necessary to insert the new release tag via a git commit locally before pushing this tag than to the `develop` branch. This will trigger a release.