### PR TITLE
Feature/simplify release process

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,11 @@
 name: build
 on:
   push:
-    branches: [ develop ]
+    branches: [ main ]
     paths:
       - "src/*"
   pull_request:
-    branches: [ develop ]
+    branches: [ main ]
 
 jobs:
   fmt-check:

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -2,7 +2,6 @@ name: releases
 
 on:
   push:
-    branches: ["develop"]
     tags:
       - "v*"
 
@@ -12,17 +11,6 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Merge develop -> main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git fetch origin main
-          git fetch origin develop
-          git checkout main
-          git merge develop --ff-only
-          git push origin main
 
       - name: new-version
         id: version
@@ -46,7 +34,7 @@ jobs:
           github_token: ${{secrets.GITHUB_TOKEN}}
           workflow: build.yml
           workflow_conclusion: success
-          branch: develop
+          commit: ${{github.event.push.head.sha}} # note: by the time this workflow runs, we expect the tagged commit build has already succeeded
           event: push
           path: bin/
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing to Collie
+
+## How to release new code
+
+We are using GitHub Action as CI/CD solution for Collie. The definition of releasing pipeline can be found here: `.github/workflows/releases.yml`. The versions have this format `va.b.c`, e.g. `v0.1.0`. The first number (`a`) representing a breaking change, the second (`b`) indicates new features and the third (`c`) indicates patches. As of right now, the release pipeline increases only the feature indicator (`b`) by one on each release. It does this automatically. In case there is a breaking change, manual intervention is required by the Collie team to ensure that the first number (`a`) is increased.
+
+The release will be triggered on each push on `develop` with a new version tag. The triggered process makes sure that `main` always contains the code up to the tagged release version. Direct pushes to `main` are prevented. The full workflow from forth to back is as follows:
+
+- For changes on code a new branch must be created from `develop`. E.g. you create a new great feature that is ready for review. You create a branch `feature/something-really-great`. After approval ✅,  you merge this branch into `develop`.
+- You want to release this code as a new feature release (e.g. going from `v0.2.0` to `v0.3.0`), so add a 
+
+- **Important: Don't forget to change the version number in `version.ts` to the version you are about to tag. This process is sadly not automated at the moment.**
+- Tag your new release PR with e.g. `git tag -a v1.4.0`
+- You open a pull request that merges `feature/something-really-great` into `develop`. **Make sure to use the merge strategy 'Rebase and Merge' and NOT Squash**. You will need at least one approval from someone for this.
+- After merging the PR into `develop`, a new release is created shortly after. This is all automatic. The install script also always works with the latest version, so you're done. Nice! 🎉 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,28 +2,30 @@
 
 ## Contributing Pull Requests
 
-For changes on code a new branch must be created from `main`. E.g. you create a new great feature that is ready for review. You create a branch `feature/something-really-great` and submit it as a PR against `main`. After approval ✅ your code is merged as usual.
+For changes on code a new branch must be created from `main`. E.g. you create a new great feature that is ready for review.
+You create a branch `feature/something-really-great` and submit it as a PR against `main`.
+After approval ✅ your code is merged as usual.
 
 ## How to release new code
 
-We are using GitHub Action as CI/CD pipeline for Collie, specifically this [release workflow](.github/workflows/releases.yml). 
+We are using GitHub Action as CI/CD pipeline for Collie, specifically this [release workflow](.github/workflows/releases.yml).
 
 The versions have this format `vMAJOR.MINOR.PATCH`, e.g. `v0.1.0`.
 
 - `MAJOR` representing a breaking change
-- `MINOR` indicates new features 
+- `MINOR` indicates new features
 - `PATCH` indicates backwards-compatible patches
 
-The release is triggered on each push on `main` with a new version tag. 
-The triggered process makes sure that `main` always contains the code up to the tagged release version. 
+The release is triggered on each push on `main` with a new version tag.
+The triggered process makes sure that `main` always contains the code up to the tagged release version.
 
 Direct pushes to `main` are prevented. The full workflow from forth to back is as follows:
 
 - decide on the version number you want to use for the release
-- **Important: Don't forget to change the version number in `version.ts` to the version you are about to tag. This process is sadly not automated at the moment.**
-- create a pull request with all version number bumps
-- Release PRs must be merged using the merge strategy 'Rebase and Merge' and NOT Squash. 
-- tag the merge commit with a version tag, e.g. `git tag -a v1.4.0`
-- the release is created automatically by the pipeline. This is all automatic.
+- **Important: Change the version number in `version.ts`. This process is sadly not automated at the moment.**
+- create a "release vX.Y.Z" pull request containing that version number bump
+- release PRs must be merged using the merge strategy 'Rebase and Merge' and NOT Squash.
+- manually tag the resulting merge commit with a version tag, e.g. `git tag -a v1.4.0` and push the tag to github
+- the release is created automatically by the [release workflow](.github/workflows/releases.yml)
 
-> Note: The install script also always works with the latest version, so you're done. Nice! 🎉 
+> Note: The install script also always works with the latest version, so you're done. Nice! 🎉

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,15 +1,29 @@
 # Contributing to Collie
 
+## Contributing Pull Requests
+
+For changes on code a new branch must be created from `main`. E.g. you create a new great feature that is ready for review. You create a branch `feature/something-really-great` and submit it as a PR against `main`. After approval ✅ your code is merged as usual.
+
 ## How to release new code
 
-We are using GitHub Action as CI/CD solution for Collie. The definition of releasing pipeline can be found here: `.github/workflows/releases.yml`. The versions have this format `va.b.c`, e.g. `v0.1.0`. The first number (`a`) representing a breaking change, the second (`b`) indicates new features and the third (`c`) indicates patches. As of right now, the release pipeline increases only the feature indicator (`b`) by one on each release. It does this automatically. In case there is a breaking change, manual intervention is required by the Collie team to ensure that the first number (`a`) is increased.
+We are using GitHub Action as CI/CD pipeline for Collie, specifically this [release workflow](.github/workflows/releases.yml). 
 
-The release will be triggered on each push on `develop` with a new version tag. The triggered process makes sure that `main` always contains the code up to the tagged release version. Direct pushes to `main` are prevented. The full workflow from forth to back is as follows:
+The versions have this format `vMAJOR.MINOR.PATCH`, e.g. `v0.1.0`.
 
-- For changes on code a new branch must be created from `develop`. E.g. you create a new great feature that is ready for review. You create a branch `feature/something-really-great`. After approval ✅,  you merge this branch into `develop`.
-- You want to release this code as a new feature release (e.g. going from `v0.2.0` to `v0.3.0`), so add a 
+- `MAJOR` representing a breaking change
+- `MINOR` indicates new features 
+- `PATCH` indicates backwards-compatible patches
 
+The release is triggered on each push on `main` with a new version tag. 
+The triggered process makes sure that `main` always contains the code up to the tagged release version. 
+
+Direct pushes to `main` are prevented. The full workflow from forth to back is as follows:
+
+- decide on the version number you want to use for the release
 - **Important: Don't forget to change the version number in `version.ts` to the version you are about to tag. This process is sadly not automated at the moment.**
-- Tag your new release PR with e.g. `git tag -a v1.4.0`
-- You open a pull request that merges `feature/something-really-great` into `develop`. **Make sure to use the merge strategy 'Rebase and Merge' and NOT Squash**. You will need at least one approval from someone for this.
-- After merging the PR into `develop`, a new release is created shortly after. This is all automatic. The install script also always works with the latest version, so you're done. Nice! 🎉 
+- create a pull request with all version number bumps
+- Release PRs must be merged using the merge strategy 'Rebase and Merge' and NOT Squash. 
+- tag the merge commit with a version tag, e.g. `git tag -a v1.4.0`
+- the release is created automatically by the pipeline. This is all automatic.
+
+> Note: The install script also always works with the latest version, so you're done. Nice! 🎉 

--- a/default.nix
+++ b/default.nix
@@ -1,8 +1,5 @@
 { pkgs ? import <nixpkgs> { } }:
 
-let
-  unstable = import <nixos-unstable> {}; # deno latest is only available as an unstable package right now
-in
 pkgs.mkShell {
   NIX_SHELL = "collie-cli";
   shellHook = ''
@@ -10,7 +7,7 @@ pkgs.mkShell {
   '';
 
   buildInputs = [
-    unstable.deno
+    pkgs.deno
     
     # used for build scripts
     pkgs.unzip


### PR DESCRIPTION
Aims to fix #133 by avoiding a potential confusion of the download-artifacts step fetching a wrong build from the wrong develop branch build because the commit sha is no explicitly fixed.

Also should fix the issue with git history containing tags on commits that are actually not part of main branch (see https://github.com/meshcloud/collie-cli/issues/133#issuecomment-1016869308  for details)

Merging this PR requires some additional manual changes that can't be included here

- [ ] move branch protection rules from develop to main
- [ ] remove contributing info from wiki