### PR TITLE
Feature/collie upgrade

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,7 @@ set -e
 
 cli_name="collie"
 
-deno_flags="--unstable --allow-read --allow-write --allow-env --allow-run"
+deno_flags=$(deno run flags.ts --quiet)
 
 mkdir -p bin/unix bin/windows
 
@@ -20,8 +20,6 @@ compile_windows(){
   deno compile $deno_flags --target "$target" --output "./bin/windows/$cli_name-$target" src/main.ts
  
 }
-
-deno test $deno_flags
 
 compile_unix "x86_64-unknown-linux-gnu"
 compile_unix "x86_64-apple-darwin"

--- a/flags.ts
+++ b/flags.ts
@@ -1,0 +1,2 @@
+import { FLAGS } from './src/config/info.ts';
+console.log(FLAGS);

--- a/run.sh
+++ b/run.sh
@@ -3,4 +3,5 @@
 set -o errexit
 set -o nounset
 
-deno run --allow-read --allow-run --allow-write --allow-env --unstable main.ts "$@"
+deno_flags=$(deno run flags.ts --quiet)
+deno run $deno_flags src/main.ts "$@"

--- a/src/commands/config.command.ts
+++ b/src/commands/config.command.ts
@@ -79,7 +79,7 @@ async function changeConnectedConfig(options: CmdConfigOpts, program: Command) {
   console.log(`Changed config file in ${configFilePath}`);
 }
 
-export function registerConfigCmd(program: Command) {
+export function registerConfigCommand(program: Command) {
   const configCmd = new Command()
     .type("platform", platform)
     .option(

--- a/src/commands/init-commands.ts
+++ b/src/commands/init-commands.ts
@@ -36,10 +36,10 @@ export function initCommands(): Command {
       {
         default: false,
         global: true,
-      }
+      },
     )
     .description(
-      `${CLIName} CLI - Herd your cloud environments with Collie. Built with love by meshcloud.io`
+      `${CLIName} CLI - Herd your cloud environments with Collie. Built with love by meshcloud.io`,
     );
 
   registerConfigCommand(program);

--- a/src/commands/init-commands.ts
+++ b/src/commands/init-commands.ts
@@ -2,7 +2,7 @@ import { Command, CompletionsCommand } from "../deps.ts";
 import { OutputFormat } from "../presentation/output-format.ts";
 import { registerCacheCommand } from "./cache.command.ts";
 import { OutputFormatType } from "./cmd-options.ts";
-import { registerConfigCmd } from "./config.command.ts";
+import { registerConfigCommand } from "./config.command.ts";
 import { registerFeedbackCommand } from "./feedback.command.ts";
 import { registerTenantCommand } from "./tenant.command.ts";
 import { CLICommand, CLIName } from "../config/config.model.ts";
@@ -11,6 +11,7 @@ import { VERSION } from "../config/info.ts";
 import { isWindows } from "../os.ts";
 import { registerUserCommand } from "./user.command.ts";
 import { registerTagCommand } from "./tag/tag.command.ts";
+import { registerUpgradeCommand } from "./upgrade.ts";
 
 export function initCommands(): Command {
   const program = new Command()
@@ -21,14 +22,10 @@ export function initCommands(): Command {
     })
     .version(VERSION)
     .type("output", OutputFormatType)
-    .option(
-      "-o --output [output:output]",
-      "Defines the output format.",
-      {
-        default: OutputFormat.TABLE,
-        global: true,
-      },
-    )
+    .option("-o --output [output:output]", "Defines the output format.", {
+      default: OutputFormat.TABLE,
+      global: true,
+    })
     .option("--debug [boolean:boolean]", "Display debug logs", {
       default: false,
       global: true,
@@ -39,22 +36,22 @@ export function initCommands(): Command {
       {
         default: false,
         global: true,
-      },
+      }
     )
     .description(
-      `${CLIName} CLI - Herd your cloud environments with Collie. Built with love by meshcloud.io`,
+      `${CLIName} CLI - Herd your cloud environments with Collie. Built with love by meshcloud.io`
     );
 
-  registerConfigCmd(program);
+  registerConfigCommand(program);
   registerTenantCommand(program);
   registerTagCommand(program);
   registerCreateIssueCommand(program);
   registerFeedbackCommand(program);
   registerCacheCommand(program);
   registerUserCommand(program);
+  registerUpgradeCommand(program);
 
-  program
-    .command("completions", new CompletionsCommand());
+  program.command("completions", new CompletionsCommand());
 
   return program;
 }

--- a/src/commands/init-commands.ts
+++ b/src/commands/init-commands.ts
@@ -7,7 +7,7 @@ import { registerFeedbackCommand } from "./feedback.command.ts";
 import { registerTenantCommand } from "./tenant.command.ts";
 import { CLICommand, CLIName } from "../config/config.model.ts";
 import { registerCreateIssueCommand } from "./create-issue.command.ts";
-import { VERSION } from "../config/version.ts";
+import { VERSION } from "../config/info.ts";
 import { isWindows } from "../os.ts";
 import { registerUserCommand } from "./user.command.ts";
 import { registerTagCommand } from "./tag/tag.command.ts";

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -1,0 +1,35 @@
+import { path, Command, GithubProvider, UpgradeCommand } from '../deps.ts';
+import { GITHUB_REPO, FLAGS, VERSION } from '../config/info.ts';
+
+export function registerUpgradeCommand(program: Command) {
+  const denoExecutable = Deno.execPath();
+  const isRuntime = path.basename(denoExecutable) === "deno"; // simple and stupid, but avoids recursively invoking ourselves!
+
+  if (!isRuntime) {
+    const msg = `Upgrade is only supported when collie cli was installed via "deno install".`;
+    program
+      .command("upgrade")
+      .description(msg)
+      .action(() => {
+        console.error(
+          msg
+          + `\nThis version at ${denoExecutable} appears to be a self-contained binary.\n`
+          + `\nTry installing via:\n`
+          + `\n\tdeno install ${FLAGS} https://raw.githubusercontent.com/${GITHUB_REPO}/v${VERSION}/cli/unipipe/main.ts`
+
+        );
+        Deno.exit(1);
+      });
+  }
+  else {
+    program.command(
+      "upgrade",
+      new UpgradeCommand({
+        args: FLAGS.split(" "),
+        provider: [
+          new GithubProvider({ repository: GITHUB_REPO }),
+        ],
+      }),
+    );
+  }
+}

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -1,27 +1,26 @@
-import { path, Command, GithubProvider, UpgradeCommand } from '../deps.ts';
-import { GITHUB_REPO, FLAGS, VERSION } from '../config/info.ts';
+import { Command, GithubProvider, path, UpgradeCommand } from "../deps.ts";
+import { FLAGS, GITHUB_REPO, VERSION } from "../config/info.ts";
 
 export function registerUpgradeCommand(program: Command) {
   const denoExecutable = Deno.execPath();
   const isRuntime = path.basename(denoExecutable) === "deno"; // simple and stupid, but avoids recursively invoking ourselves!
 
   if (!isRuntime) {
-    const msg = `Upgrade is only supported when collie cli was installed via "deno install".`;
+    const msg =
+      `Upgrade is only supported when collie cli was installed via "deno install".`;
     program
       .command("upgrade")
       .description(msg)
       .action(() => {
         console.error(
-          msg
-          + `\nThis version at ${denoExecutable} appears to be a self-contained binary.\n`
-          + `\nTry installing via:\n`
-          + `\n\tdeno install ${FLAGS} https://raw.githubusercontent.com/${GITHUB_REPO}/v${VERSION}/cli/unipipe/main.ts`
-
+          msg +
+            `\nThis version at ${denoExecutable} appears to be a self-contained binary.\n` +
+            `\nTry installing via:\n` +
+            `\n\tdeno install ${FLAGS} https://raw.githubusercontent.com/${GITHUB_REPO}/v${VERSION}/cli/unipipe/main.ts`,
         );
         Deno.exit(1);
       });
-  }
-  else {
+  } else {
     program.command(
       "upgrade",
       new UpgradeCommand({

--- a/src/config/config.model.ts
+++ b/src/config/config.model.ts
@@ -1,5 +1,5 @@
 import { readFile, writeFile } from "../commands/io.ts";
-import { path, ensureDir, } from "../deps.ts";
+import { ensureDir, path } from "../deps.ts";
 import { parseJsonWithLog } from "../json.ts";
 import { isWindows } from "../os.ts";
 

--- a/src/config/config.model.ts
+++ b/src/config/config.model.ts
@@ -1,21 +1,21 @@
 import { readFile, writeFile } from "../commands/io.ts";
-import { dirname, ensureDir, join } from "../deps.ts";
+import { path, ensureDir, } from "../deps.ts";
 import { parseJsonWithLog } from "../json.ts";
 import { isWindows } from "../os.ts";
 
 function getConfigPath(): string {
-  const path = join(".config", "collie-cli");
+  const configPath = path.join(".config", "collie-cli");
   let home = "";
   if (isWindows) {
     home = Deno.env.get("APPDATA") || "";
   } else {
     home = Deno.env.get("HOME") || "";
   }
-  return join(home, path);
+  return path.join(home, configPath);
 }
 
 export const configPath = getConfigPath();
-export const configFilePath = join(configPath, "config.json");
+export const configFilePath = path.join(configPath, "config.json");
 // Use the CLI Name when mentioning it somewhere in a sentence, e.g.: Have fun using ${CLIName}!
 export const CLIName = "Collie";
 // Use the CLI Command when mentioning it as a command to run, e.g.: Please run "${CLICommand} -h" to see more.
@@ -87,6 +87,6 @@ export function loadConfig(): Config {
 }
 
 export async function writeConfig(config: Config) {
-  await ensureDir(dirname(configFilePath));
+  await ensureDir(path.dirname(configFilePath));
   writeFile(configFilePath, JSON.stringify(config, null, 2));
 }

--- a/src/config/info.ts
+++ b/src/config/info.ts
@@ -1,2 +1,3 @@
 export const VERSION = "0.9.1";
 export const FLAGS = "--unstable --allow-read --allow-write --allow-env --allow-run";
+export const GITHUB_REPO = "meshcloud/collie-cli";

--- a/src/config/info.ts
+++ b/src/config/info.ts
@@ -1,0 +1,2 @@
+export const VERSION = "0.9.1";
+export const FLAGS = "--unstable --allow-read --allow-write --allow-env --allow-run";

--- a/src/config/info.ts
+++ b/src/config/info.ts
@@ -1,3 +1,4 @@
 export const VERSION = "0.9.1";
-export const FLAGS = "--unstable --allow-read --allow-write --allow-env --allow-run";
+export const FLAGS =
+  "--unstable --allow-read --allow-write --allow-env --allow-run";
 export const GITHUB_REPO = "meshcloud/collie-cli";

--- a/src/config/version.ts
+++ b/src/config/version.ts
@@ -1,1 +1,0 @@
-export const VERSION = "0.9.1";

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -14,7 +14,7 @@ export {
   exists,
   existsSync,
 } from "https://deno.land/std@0.116.0/fs/mod.ts";
-export { dirname, join } from "https://deno.land/std@0.116.0/path/mod.ts";
+export * as path from "https://deno.land/std@0.116.0/path/mod.ts";
 export {
   bold,
   brightBlue,
@@ -33,14 +33,18 @@ export {
   CompletionsCommand,
   EnumType,
   Type,
-} from "https://deno.land/x/cliffy@v0.19.2/command/mod.ts";
-export type { ITypeInfo } from "https://deno.land/x/cliffy@v0.19.2/command/mod.ts";
-export { Table } from "https://deno.land/x/cliffy@v0.19.2/table/mod.ts";
+} from "https://deno.land/x/cliffy@v0.20.1/command/mod.ts";
+export type { ITypeInfo } from "https://deno.land/x/cliffy@v0.20.1/command/mod.ts";
+export { Table } from "https://deno.land/x/cliffy@v0.20.1/table/mod.ts";
 export {
   Confirm,
   Input,
   Select,
-} from "https://deno.land/x/cliffy@v0.19.2/prompt/mod.ts";
+} from "https://deno.land/x/cliffy@v0.20.1/prompt/mod.ts";
+export {
+  UpgradeCommand,
+  GithubProvider,
+} from "https://deno.land/x/cliffy@v0.20.1/command/upgrade/mod.ts";
 
 // other
 export * as Progress from "https://deno.land/x/progress@v1.2.3/mod.ts";

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -42,8 +42,8 @@ export {
   Select,
 } from "https://deno.land/x/cliffy@v0.20.1/prompt/mod.ts";
 export {
-  UpgradeCommand,
   GithubProvider,
+  UpgradeCommand,
 } from "https://deno.land/x/cliffy@v0.20.1/command/upgrade/mod.ts";
 
 // other

--- a/test.sh
+++ b/test.sh
@@ -3,4 +3,5 @@
 set -o errexit
 set -o nounset
 
-deno test --allow-read --allow-run --allow-write --allow-env --unstable "$@"
+deno_flags=$(deno run flags.ts --quiet)
+deno test $deno_flags "$@"


### PR DESCRIPTION
Re #108, while this does not give users a "a new update is available prompt" I'm hopeful this can be built more easily atop cliffy's `GitHubProvider.getVersions()` call