### PR TITLE
fix: date serialization issue in tenant cost command json output

### DIFF
--- a/src/api/aws/AwsMeshAdapter.ts
+++ b/src/api/aws/AwsMeshAdapter.ts
@@ -206,8 +206,8 @@ export class AwsMeshAdapter implements MeshAdapter {
 
         const costItem: MeshTenantCost = {
           currency: "",
-          from: from.toDate(),
-          to: to.toDate(),
+          from: from.toDate().toISOString(),
+          to: to.toDate().toISOString(),
           cost: "0",
           details: [],
         };

--- a/src/api/az/AzMeshAdapter.ts
+++ b/src/api/az/AzMeshAdapter.ts
@@ -104,8 +104,8 @@ export class AzMeshAdapter implements MeshAdapter {
       t.costs.push({
         currency: currencySymbol,
         cost: summedCost.toString(),
-        from: startDate,
-        to: endDate,
+        from: from,
+        to: to,
         details: [],
       });
     }

--- a/src/api/gcloud/GcloudMeshAdapter.ts
+++ b/src/api/gcloud/GcloudMeshAdapter.ts
@@ -167,8 +167,8 @@ export class GcloudMeshAdapter implements MeshAdapter {
         const invoiceMonthString = moment(window.from).format("YYYYMM");
         const tenantCostItem: MeshTenantCost = {
           currency: "",
-          from: window.from,
-          to: window.to,
+          from: window.from.toISOString(),
+          to: window.to.toISOString(),
           cost: "0",
           details: [],
         };

--- a/src/mesh/MeshTenantModel.ts
+++ b/src/mesh/MeshTenantModel.ts
@@ -33,10 +33,12 @@ export interface MeshTenantCostDetails {
   usageCost: string;
 }
 
+export type IsoDate = string;
+
 export interface MeshTenantCost {
   cost: string;
-  from: Date;
-  to: Date;
+  from: IsoDate;
+  to: IsoDate;
   currency: string;
   details: MeshTenantCostDetails[];
 }

--- a/src/presentation/json-presenter.ts
+++ b/src/presentation/json-presenter.ts
@@ -60,8 +60,8 @@ export class JsonPresenter<T> implements Presenter {
         relatedTenant: JsonPresenter.meshTenantToJsonView(meshTenant),
         totalUsageCost: c.cost,
         currency: c.currency,
-        from: c.from.toISOString(),
-        to: c.to.toISOString(),
+        from: c.from,
+        to: c.to,
       };
     });
   }


### PR DESCRIPTION
now using ISO date strings in our models as that simplifies handling
serialization/deserialization when collie cache is involved