### PR TITLE
feat: collie init ensures an initialized git repo

### DIFF
--- a/src/api/CliApiFacadeFactory.ts
+++ b/src/api/CliApiFacadeFactory.ts
@@ -33,6 +33,8 @@ import { NpmCliDetector } from "./npm/NpmCliDetector.ts";
 import { NpmCliFacade } from "./npm/NpmCliFacade.ts";
 import { TerraformDocsCliFacade } from "./terraform-docs/TerraformDocsCliFacade.ts";
 import { CollieRepository } from "../model/CollieRepository.ts";
+import { GitCliDetector } from "./git/GitCliDetector.ts";
+import { GitCliFacade } from "./git/GitCliFacade.ts";
 
 export class CliApiFacadeFactory {
   constructor(
@@ -46,6 +48,7 @@ export class CliApiFacadeFactory {
       new AwsCliDetector(processRunner),
       new AzCliDetector(processRunner),
       new GcloudCliDetector(processRunner),
+      new GitCliDetector(processRunner),
       new TerraformCliDetector(processRunner),
       new TerragruntCliDetector(processRunner),
       new TerraformDocsCliDetector(processRunner),
@@ -109,6 +112,15 @@ export class CliApiFacadeFactory {
     azure = new RetryingAzCliDecorator(azure);
 
     return azure;
+  }
+
+  public buildGit() {
+    const detectorRunner = this.buildProcessRunner();
+    const detector = new GitCliDetector(detectorRunner);
+
+    const processRunner = this.buildTransparentProcessRunner(detector);
+
+    return new GitCliFacade(processRunner);
   }
 
   public buildTerragrunt() {

--- a/src/api/git/GitCliDetector.ts
+++ b/src/api/git/GitCliDetector.ts
@@ -1,0 +1,22 @@
+import { IProcessRunner } from "../../process/IProcessRunner.ts";
+import { ProcessResultWithOutput } from "../../process/ProcessRunnerResult.ts";
+import { CliDetector } from "../CliDetector.ts";
+
+export class GitCliDetector extends CliDetector {
+  constructor(runner: IProcessRunner<ProcessResultWithOutput>) {
+    super("git", runner);
+  }
+
+  protected parseVersion(versionCmdOutput: string): string {
+    const components = versionCmdOutput.split(" ");
+
+    const version = components[0].substring("git version ".length);
+
+    return version;
+  }
+
+  protected isSupportedVersion(version: string): boolean {
+    // a simple lexicographic comparison is sufficient for our needs
+    return version > "2.0.0";
+  }
+}

--- a/src/api/git/GitCliFacade.ts
+++ b/src/api/git/GitCliFacade.ts
@@ -1,0 +1,12 @@
+import { IProcessRunner } from "../../process/IProcessRunner.ts";
+import { ProcessResult } from "../../process/ProcessRunnerResult.ts";
+
+export class GitCliFacade {
+  constructor(private readonly processRunner: IProcessRunner<ProcessResult>) {}
+
+  async init() {
+    // note: rerunning git init is safe
+    // https://stackoverflow.com/questions/5149694/does-running-git-init-twice-initialize-a-repository-or-reinitialize-an-existing
+    await this.processRunner.run(["git", "init"]);
+  }
+}

--- a/src/commands/init.command.ts
+++ b/src/commands/init.command.ts
@@ -7,6 +7,7 @@ import {
 } from "../cli/DirectoryGenerator.ts";
 import { CollieRepository } from "../model/CollieRepository.ts";
 import { GlobalCommandOptions } from "./GlobalCommandOptions.ts";
+import { CliApiFacadeFactory } from "../api/CliApiFacadeFactory.ts";
 
 export function registerInitCommand(program: Command) {
   program
@@ -15,6 +16,12 @@ export function registerInitCommand(program: Command) {
     .action(async (opts: GlobalCommandOptions) => {
       const kit = new CollieRepository("./");
       const logger = new Logger(kit, opts);
+
+      // ensure git is initialized
+      const cliFactory = new CliApiFacadeFactory(kit, logger);
+      const git = cliFactory.buildGit();
+
+      await git.init();
 
       const dir = new DirectoryGenerator(WriteMode.skip, logger);
       const d: Dir = {


### PR DESCRIPTION
as long as we use presence of .git to detect a collie repo, we should also ensure that collie init creates git repos

closes #165