### PR TITLE
feat: support running collie commands from subdirectories of repo

### DIFF
--- a/src/FirstTimeExperience.ts
+++ b/src/FirstTimeExperience.ts
@@ -3,7 +3,7 @@ import { CollieRepository } from "./model/CollieRepository.ts";
 
 export class FirstTimeExperience {
   static async tryShowTips() {
-    const collie = new CollieRepository("./");
+    const collie = await CollieRepository.load();
 
     const foundations = await collie.listFoundations();
     if (!foundations.length) {

--- a/src/commands/FoundationType.ts
+++ b/src/commands/FoundationType.ts
@@ -3,6 +3,8 @@ import { StringType } from "../deps.ts";
 
 export class FoundationType extends StringType {
   async complete(): Promise<string[]> {
-    return await new CollieRepository("./").listFoundations();
+    const collie = await CollieRepository.load();
+
+    return await collie.listFoundations();
   }
 }

--- a/src/commands/foundation/config.command.ts
+++ b/src/commands/foundation/config.command.ts
@@ -13,7 +13,7 @@ export function registerConfigCmd(program: Command) {
     .command("config")
     .description("show cloud foundation config file tree")
     .action(async (opts: GlobalCommandOptions) => {
-      const repo = await CollieRepository.load("./");
+      const repo = await CollieRepository.load();
       const logger = new Logger(repo, opts);
 
       const foundations = await repo.listFoundations();

--- a/src/commands/foundation/deploy.command.ts
+++ b/src/commands/foundation/deploy.command.ts
@@ -73,7 +73,7 @@ export function registerDeployCmd(program: Command) {
       ) => {
         const literalArgs = LiteralArgsParser.parse(cmd.getRawArgs());
 
-        const collieRepo = new CollieRepository("./");
+        const collieRepo = await CollieRepository.load();
         const logger = new Logger(collieRepo, opts);
         const validator = new ModelValidator(logger);
 

--- a/src/commands/foundation/docs.command.ts
+++ b/src/commands/foundation/docs.command.ts
@@ -33,7 +33,7 @@ export function registerDocsCmd(program: Command) {
         opts: GlobalCommandOptions & DocsCommandOptions,
         foundation: string,
       ) => {
-        const repo = new CollieRepository("./");
+        const repo = await CollieRepository.load();
         const logger = new Logger(repo, opts);
         const validator = new ModelValidator(logger);
 

--- a/src/commands/foundation/new.command.ts
+++ b/src/commands/foundation/new.command.ts
@@ -22,7 +22,7 @@ export function registerNewCmd(program: Command) {
     .command("new <foundation:foundation>")
     .description("generate a new cloud foundation")
     .action(async (opts: GlobalCommandOptions, foundation: string) => {
-      const repo = await CollieRepository.load("./");
+      const repo = await CollieRepository.load();
       const logger = new Logger(repo, opts);
 
       const foundationPath = repo.resolvePath("foundations", foundation);

--- a/src/commands/interactive/interactive.command.ts
+++ b/src/commands/interactive/interactive.command.ts
@@ -25,7 +25,7 @@ export async function startInteractiveMode(options: GlobalCommandOptions) {
   const interactivehelp =
     `\n\n\nWelcome to ${CLI} interactive mode. This experimental mode allows you to herd your tenants in a quicker, more interactive way.\n\n\n "LIST ALL TENANTS"\nis equivalent to "${CLI} tenant list"\n\n"LIST ALL TENANTS WITH COST"\nis equivalent to "${CLI} tenant costs"\n\n"EXPLORE TENANTS WITH MISSING TAGS"\nis the superpower of the interactive mode. Go check it out!\n\n`;
 
-  const collie = new CollieRepository("./");
+  const collie = await CollieRepository.load();
 
   const foundation = await InteractivePrompts.selectFoundation(collie);
 

--- a/src/commands/tenant/prepareTenantCommand.ts
+++ b/src/commands/tenant/prepareTenantCommand.ts
@@ -13,7 +13,7 @@ export async function prepareTenantCommand(
   options: GlobalCommandOptions & TenantCommandOptions,
   foundation: string,
 ) {
-  const collieRepo = await CollieRepository.load("./");
+  const collieRepo = await CollieRepository.load();
 
   const logger = new Logger(collieRepo, options);
 

--- a/src/model/CollieRepository.ts
+++ b/src/model/CollieRepository.ts
@@ -38,7 +38,7 @@ export class CollieRepository {
     }
   }
 
-  static async load(searchDir: string) {
+  static async load(searchDir = "./"): Promise<CollieRepository> {
     const absolutePath = path.resolve(searchDir);
     const components = absolutePath.split(path.SEP);
 


### PR DESCRIPTION
always traverse the path to the nearest collie repository root for all commands except "collie init"