### PR TITLE
feat: fetch azure locations via az cli

### DIFF
--- a/src/api/az/AutoInstallAzModuleAzCliDecorator.ts
+++ b/src/api/az/AutoInstallAzModuleAzCliDecorator.ts
@@ -3,6 +3,7 @@ import { AzureErrorCode, MeshAzurePlatformError } from "/errors.ts";
 import { AzCliFacade, DynamicInstallValue } from "./AzCliFacade.ts";
 import {
   Account,
+  AzLocation,
   AzureMeshTag,
   Entity,
   RoleAssignment,
@@ -37,6 +38,12 @@ export class AutoInstallAzModuleAzCliDecorator implements AzCliFacade {
   async listSubscriptions(): Promise<Subscription[]> {
     return await this.wrapCallWithInstallInterception(() => {
       return this.azureFacade.listSubscriptions();
+    });
+  }
+
+  async listLocations(): Promise<AzLocation[]> {
+    return await this.wrapCallWithInstallInterception(() => {
+      return this.azureFacade.listLocations();
     });
   }
 

--- a/src/api/az/AzCli.ts
+++ b/src/api/az/AzCli.ts
@@ -1,6 +1,7 @@
 import { AzCliFacade, DynamicInstallValue } from "./AzCliFacade.ts";
 import {
   Account,
+  AzLocation,
   AzureMeshTag,
   CostManagementInfo,
   Entity,
@@ -61,6 +62,16 @@ export class AzCli implements AzCliFacade {
 
   async listSubscriptions(): Promise<Subscription[]> {
     const result = await this.processRunner.run(["az", "account", "list"]);
+
+    return parseJsonWithLog(result.stdout);
+  }
+
+  async listLocations(): Promise<AzLocation[]> {
+    const result = await this.processRunner.run([
+      "az",
+      "account",
+      "list-locations",
+    ]);
 
     return parseJsonWithLog(result.stdout);
   }

--- a/src/api/az/AzCliFacade.ts
+++ b/src/api/az/AzCliFacade.ts
@@ -1,5 +1,6 @@
 import {
   Account,
+  AzLocation,
   AzureMeshTag,
   Entity,
   RoleAssignment,
@@ -29,4 +30,6 @@ export interface AzCliFacade {
   ): Promise<SimpleCostManagementInfo[]>;
 
   getRoleAssignments(subscription: Subscription): Promise<RoleAssignment[]>;
+
+  listLocations(): Promise<AzLocation[]>;
 }

--- a/src/api/az/AzPlatformSetup.ts
+++ b/src/api/az/AzPlatformSetup.ts
@@ -13,7 +13,7 @@ export class AzPlatformSetup extends PlatformSetup<PlatformConfigAzure> {
   }
 
   async promptInteractively(): Promise<PlatformConfigAzure> {
-    // todo: shoudl this be id of the platform instead?
+    // todo: should this be id of the platform instead?
     // todo: AZURE_CONFIG_DIR?
     const { id, name } = await this.promptPlatformName();
 

--- a/src/api/az/Model.ts
+++ b/src/api/az/Model.ts
@@ -93,3 +93,15 @@ export interface RoleAssignment {
   // "/providers/Microsoft.Management/managementGroups/<mg-id>" -> meaning from a management group
   // "/subscriptions/<sub-id>" -> meaning directly assigned on a subscription.
 }
+
+export interface AzLocation {
+  displayName: string;
+  id: string;
+  name: string;
+  regionalDisplayName: string;
+  metadata: {
+    regionType: string;
+    geographyGroup: string | null;
+    physicalLocation: string | null;
+  };
+}

--- a/src/api/az/RetryingAzCliDecorator.ts
+++ b/src/api/az/RetryingAzCliDecorator.ts
@@ -3,6 +3,7 @@ import { sleep } from "/promises.ts";
 import { AzCliFacade, DynamicInstallValue } from "./AzCliFacade.ts";
 import {
   Account,
+  AzLocation,
   AzureMeshTag,
   Entity,
   RoleAssignment,
@@ -30,6 +31,12 @@ export class RetryingAzCliDecorator implements AzCliFacade {
   async listSubscriptions(): Promise<Subscription[]> {
     return await this.retryable(async () => {
       return await this.wrapped.listSubscriptions();
+    });
+  }
+
+  async listLocations(): Promise<AzLocation[]> {
+    return await this.retryable(async () => {
+      return await this.wrapped.listLocations();
     });
   }
 

--- a/src/commands/kit/bundles/azure-caf-es.ts
+++ b/src/commands/kit/bundles/azure-caf-es.ts
@@ -8,6 +8,8 @@ import {
 } from "./kitbundle.ts";
 import { ensureBackedUpFile } from "../kit-utilities.ts";
 import { InputParameter } from "../../InputParameter.ts";
+import { SelectValueOptions } from "x/cliffy/prompt";
+import { AzLocation } from "../../../api/az/Model.ts";
 
 // Define Parameter names globally for easier change:
 // bootstrap module
@@ -22,7 +24,9 @@ const PARAM_ROOT_NAME = "Root Name";
 const PARAM_DEFAULT_LOCATION = "Default Location";
 
 export class AzureKitBundle extends KitBundle {
-  constructor() {
+  locations: AzLocation[];
+
+  constructor(locations: AzLocation[]) {
     const identifier = "azure-caf-es";
     const displayName = "Azure Enterprise Scale";
     const description =
@@ -49,9 +53,16 @@ export class AzureKitBundle extends KitBundle {
       }`;
 
     super(identifier, displayName, description);
+    this.locations = locations;
   }
 
   kitsAndSources(): Map<string, KitRepresentation> {
+    const azureLocationOptions: SelectValueOptions = this.locations.map((
+      location: AzLocation,
+    ) => ({
+      name: location.displayName,
+      value: location.name,
+    }));
     const bootstrapKitParams: InputParameter[] = [
       {
         description: PARAM_PE_UPN,
@@ -389,59 +400,3 @@ export class AzureKitBundle extends KitBundle {
     Deno.writeTextFileSync(platformHCL, text);
   }
 }
-
-// TODO instead of hardcoding all locations, we should fetch them via az cli: "az account list-locations"
-// For comparison, see AwsCliFacade.ts, which already includes the method listRegions. We need something
-// comparable, but for Azure.
-const azureLocationOptions = [
-  { name: "Germany North", value: "germanynorth" },
-  { name: "Germany West Central", value: "germanywestcentral" },
-  { name: "Australia Central", value: "australiacentral" },
-  { name: "Australia Central 2", value: "australiacentral2" },
-  { name: "Australia East", value: "australiaeast" },
-  { name: "Australia Southeast", value: "australiasoutheast" },
-  { name: "Brazil South", value: "brazilsouth" },
-  { name: "Brazil Southeast", value: "brazilsoutheast" },
-  { name: "Canada Central", value: "canadacentral" },
-  { name: "Canada East", value: "canadaeast" },
-  { name: "Central India", value: "centralindia" },
-  { name: "Central US", value: "centralus" },
-  { name: "Central US EUAP", value: "centraluseuap" },
-  { name: "East Asia", value: "eastasia" },
-  { name: "East US", value: "eastus" },
-  { name: "East US 2", value: "eastus2" },
-  { name: "East US 2 EUAP", value: "eastus2euap" },
-  { name: "East US STG", value: "eastusstg" },
-  { name: "France Central", value: "francecentral" },
-  { name: "France South", value: "francesouth" },
-  { name: "Japan East", value: "japaneast" },
-  { name: "Japan West", value: "japanwest" },
-  { name: "Jio India Central", value: "jioindiacentral" },
-  { name: "Jio India West", value: "jioindiawest" },
-  { name: "Korea Central", value: "koreacentral" },
-  { name: "Korea South", value: "koreasouth" },
-  { name: "North Central US", value: "northcentralus" },
-  { name: "North Europe", value: "northeurope" },
-  { name: "Norway East", value: "norwayeast" },
-  { name: "Norway West", value: "norwaywest" },
-  { name: "Qatar Central", value: "qatarcentral" },
-  { name: "South Africa North", value: "southafricanorth" },
-  { name: "South Africa West", value: "southafricawest" },
-  { name: "South Central US", value: "southcentralus" },
-  { name: "South Central US STG", value: "southcentralusstg" },
-  { name: "South India", value: "southindia" },
-  { name: "Southeast Asia", value: "southeastasia" },
-  { name: "Sweden Central", value: "swedencentral" },
-  { name: "Switzerland North", value: "switzerlandnorth" },
-  { name: "Switzerland West", value: "switzerlandwest" },
-  { name: "UAE Central", value: "uaecentral" },
-  { name: "UAE North", value: "uaenorth" },
-  { name: "UK South", value: "uksouth" },
-  { name: "UK West", value: "ukwest" },
-  { name: "West Central US", value: "westcentralus" },
-  { name: "West Europe", value: "westeurope" },
-  { name: "West India", value: "westindia" },
-  { name: "West US", value: "westus" },
-  { name: "West US 2", value: "westus2" },
-  { name: "West US 3", value: "westus3" },
-];


### PR DESCRIPTION
The Azure locations are currently hard-coded, which means we would have to update the code whenever Azure adds a new location or removes an existing location. Instead, we should use the AZ CLI to fetch available locations, similar to the way we currently fetch AWS regions via AWS CLI.