### PR TITLE
Feature/remove obsolete code

### DIFF
--- a/src/commands/kit/bundle.command.ts
+++ b/src/commands/kit/bundle.command.ts
@@ -206,10 +206,6 @@ export function registerBundledKitCmd(program: TopLevelCommand) {
             );
           }
         });
-
-        // TODO commented for now: as long as the deploy is commented, this should be commented as well,
-        // because there might be a dependency between the two.
-        // bundleToSetup.afterDeploy(platformPath, parametrization);
       },
     );
 }

--- a/src/commands/kit/bundle.command.ts
+++ b/src/commands/kit/bundle.command.ts
@@ -178,9 +178,6 @@ export function registerBundledKitCmd(program: TopLevelCommand) {
               kitRepr.deployment!.autoDeployOrder
             }`,
           );
-          // TODO this is a non-obvious and brittle way to determine if the module is a bootstrap module
-          // >> yeah, but we want to know if the module needs to be deployed twice, not if it is a bootstrap module.
-          // >> maybe other modules in the future need double-deployment, too.
           const moduleOpts = {
             module: name,
           };

--- a/src/commands/kit/bundles/azure-caf-es.ts
+++ b/src/commands/kit/bundles/azure-caf-es.ts
@@ -361,13 +361,6 @@ export class AzureKitBundle extends KitBundle {
     this.afterApplyBase(platformModuleDir, kitDir, parametrization);
   }
 
-  afterDeploy(
-    _platformModuleDir: string,
-    _parametrization: Map<string, string>,
-  ): void {
-    // nothing to be done here
-  }
-
   betweenDeployments(
     platformModuleDir: string,
     parametrization: Map<string, string>,

--- a/src/commands/kit/bundles/kitbundle.ts
+++ b/src/commands/kit/bundles/kitbundle.ts
@@ -41,12 +41,6 @@ export abstract class KitBundle {
     kitDir: string,
     parametrization: Map<string, string>,
   ): void;
-
-  // callback to be applied after we did the auto-deploy of kits
-  abstract afterDeploy(
-    platformModuleDir: string,
-    parametrization: Map<string, string>,
-  ): void;
 }
 
 export class KitRepresentation {


### PR DESCRIPTION
The function `afterDeploy` was never called anywhere and the implementation was always empty, so it's not used in any way currently.

@j0g3sc You probably know best what the original intent of this function was. Is it okay to just remove it, or do we have an implementation missing?