### PR TITLE
feat: add support for Apple Silicon at build and install time

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -25,4 +25,5 @@ compile_windows(){
 
 compile_unix "x86_64-unknown-linux-gnu"
 compile_unix "x86_64-apple-darwin"
+compile_unix "aarch64-apple-darwin"
 compile_windows "x86_64-pc-windows-msvc"

--- a/install.sh
+++ b/install.sh
@@ -3,17 +3,29 @@ set -o errexit
 set -o errtrace
 set -o pipefail
 set -o nounset
+
+#Check CPU architecture
+case $(uname -m) in
+    amd64|x86_64) arch=x86_64 ;;
+    arm64|aarch64) arch=aarch64 ;;
+    *) arch= ;;
+esac
+if [ -z "$arch" ]; then
+    echo "Architecture  $(uname -m) not supported." >&2
+    exit 1
+fi
+
 # Check if user has all required commands installed
 REQ_COMMANDS=(tar curl)
 for i in $REQ_COMMANDS
 do
   command -v "$i" >/dev/null && continue || { echo "$i command not found. You need to install if before running this script"; exit 1; }
 done
-# Download artifacts
+# Download artifacts based on CPU architecture and OS type
 case "$(uname -s)" in
    Darwin)
-     url=$(curl -s https://api.github.com/repos/meshcloud/collie-cli/releases/latest | grep "browser_download_url.*apple" | cut -d : -f 2,3 | tr -d \" | tr -d \ )
-     name="collie-x86_64-apple-darwin"
+       url=$(curl -s https://api.github.com/repos/meshcloud/collie-cli/releases/latest | grep "browser_download_url.*$arch*apple" | cut -d : -f 2,3 | tr -d \" | tr -d \ )
+       name="collie-$arch-apple-darwin"    
      ;;
    Linux)
      url=$(curl -s https://api.github.com/repos/meshcloud/collie-cli/releases/latest | grep "browser_download_url.*linux" | cut -d : -f 2,3 | tr -d \" | tr -d \ )


### PR DESCRIPTION
I needed to support Apple silicon so we could install collie-cli on our company's laptops.

This PR simply adds support in install.sh and build.sh for both CPU architectures available with MacOSX.

As a side note it will require a github release to fully work with arm64 since we need an valid artifact in there.