### PR TITLE
chore: simplify the release process

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,15 +45,17 @@ jobs:
           key: ${{ runner.os }}-deno # it seems there's no particular cache keying required
           restore-keys: |
             ${{ runner.os }}-deno
-      - run: |
+      - name: deno info
+        run: |
           deno --version
           deno info
-          ./build.sh
-
-      - name: Archive production artifacts
-        if: ${{ github.event_name != 'pull_request' }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: collie
-          path: |
-            bin/**/collie-*
+      - name: check
+        run: |
+          deno task check
+      - name: test
+        run: |
+          deno task test
+      - name: cheap integration test
+        run: |
+          deno task run
+          

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,66 +1,57 @@
 name: release
 
 on:
-  push:
-    tags:
-      - "v*"
+  release:
+    types: [published]
 
 jobs:
   create-release:
     runs-on: ubuntu-latest
     steps:
-      - name: checkout
-        uses: actions/checkout@v3
-
-      - name: new-version
-        id: version
-        shell: bash
-        run: |
-          version=$(git describe --tags `git rev-list --tags --max-count=1` --always)
-          echo "::set-output name=old-version::$(echo "${version}")"
-          if [[ ! "$version" =~ ^v.*$ ]]
-          then
-            echo "::set-output name=version::$(echo "v0.1.0")"
-            exit 0
-          fi
-          breaking=$(echo ${version/v/''} | cut -d'.' -f1)
-          minor=$(echo ${version/v/''} | cut -d'.' -f2)
-          patch=$(echo ${version/v/''} | cut -d'.' -f3)
-          echo "::set-output name=version::$(echo "v${breaking}.${minor}.${patch}")"
-
-      - name: download-artifact
-        uses: dawidd6/action-download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: denoland/setup-deno@main
         with:
-          github_token: ${{secrets.GITHUB_TOKEN}}
-          workflow: build.yml
-          workflow_conclusion: success
-          commit: ${{github.event.push.head.sha}} # note: by the time this workflow runs, we expect the tagged commit build has already succeeded
-          event: push
-          path: bin/
-
-      - name: preparing-artifacts
-        shell: bash
-        run: |
-          mkdir bin/artifacts
-          cd bin/collie/unix
-          tar -czvf ../../artifacts/collie-x86_64-apple-darwin.tar.gz collie-x86_64-apple-darwin
-          tar -czvf ../../artifacts/collie-x86_64-unknown-linux-gnu.tar.gz collie-x86_64-unknown-linux-gnu
-          cd ../../..
-          cp -a bin/collie/windows/. bin/artifacts
-
-      - name: build-changelog
-        id: build_changelog
-        uses: mikepenz/release-changelog-builder-action@v1.8.2
+          deno-version: "~1.34"
+      - uses: actions/cache@v3
         with:
-          fromTag: ${{ steps.version.outputs.old-version }}
-          toTag: ${{ steps.version.outputs.version }}
+          path: ~/.cache/deno        # see https://deno.land/manual/linking_to_external_code
+          key: ${{ runner.os }}-deno # it seems there's no particular cache keying required
+          restore-keys: |
+            ${{ runner.os }}-deno
+      - run: ./build.sh
+      - name: upload x86_64-unknown-linux-gnu
+        uses: actions/upload-release-asset@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: create-release
-        uses: ncipollo/release-action@v1
+          GITHUB_TOKEN: ${{ github.token }}
         with:
-          artifacts: bin/artifacts/*
-          body: ${{ steps.github_release.outputs.changelog }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ steps.version.outputs.version }}
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./bin/collie-x86_64-unknown-linux-gnu.tar.gz
+          asset_name: collie-x86_64-unknown-linux-gnu.tar.gz
+          asset_content_type: application/gzip
+      - name: upload x86_64-apple-darwin
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./bin/collie-x86_64-apple-darwin.tar.gz
+          asset_name: collie-x86_64-apple-darwin.tar.gz
+          asset_content_type: application/gzip
+      - name: upload aarch64-apple-darwin
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./bin/collie-aarch64-apple-darwin.tar.gz
+          asset_name: collie-aarch64-apple-darwin.tar.gz
+          asset_content_type: application/gzip
+      - name: upload x86_64-pc-windows-msvc
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./bin/collie-x86_64-pc-windows-msvc.exe
+          asset_name: collie-x86_64-pc-windows-msvc.exe
+          asset_content_type: application/vnd.microsoft.portable-executable 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,12 +26,11 @@ For changes on code a new branch must be created from `main`. E.g. you create a
 new great feature that is ready for review. You create a branch
 `feature/something-really-great` and submit it as a PR against `main`.
 
-After approval ✅ your code is merged automatically by our mergebot as soon as
-you apply the `automerge` label to your PR.
+After approval queue your changes for merging via GitHub's merge queue.
 
 ## How to release new code
 
-We are using GitHub Action as CI/CD pipeline for Collie, specifically this
+We are using GitHub Action as CI/CD pipeline for collie, specifically this
 [release workflow](.github/workflows/releases.yml).
 
 The versions have this format `vMAJOR.MINOR.PATCH`, e.g. `v0.1.0`.
@@ -40,24 +39,18 @@ The versions have this format `vMAJOR.MINOR.PATCH`, e.g. `v0.1.0`.
 - `MINOR` indicates new features
 - `PATCH` indicates backwards-compatible patches
 
-The release is triggered on each push on `main` with a new version tag. The
-triggered process makes sure that `main` always contains the code up to the
-tagged release version.
+The release is triggered by
+[creating a new release via GitHub's UI](https://github.com/meshcloud/collie-cli/releases/new)
+as this gives us a good workflow to review and edit release notes before
+publishing.
 
-Direct pushes to `main` are prevented. The full workflow from forth to back is
-as follows:
+The full workflow from forth to back is as follows:
 
-- decide on the version number you want to use for the release
-- **Important: Change the version number in `info.ts`. This process is sadly not
-  automated at the moment.**
-- create a "release vX.Y.Z" **pull request** containing that version number bump
-- release PRs must be merged using the merge strategy **'Rebase and Merge'** and NOT
-  Squash.
-- manually tag the resulting merge commit with a version tag, e.g.
-  `git tag -a v1.4.0 -m "<Tag Message>"` and push the tag to github using 'git push --tags'
-- the release is created automatically by the
+- decide on the version number you want to use for the release choose a new tag
+  "vMAJOR.MINOR.PATCH"
+- click "Generate release notes"
+- the release binaries are created automatically by the
   [release workflow](.github/workflows/releases.yml)
-- update the release note if needed in "draft a new release" with choosing the write tag 
 
-> Note: The install script also always works with the latest version, so you're
+> Note: The install script also always works with thse latest version, so you're
 > done. Nice! 🎉

--- a/build.sh
+++ b/build.sh
@@ -2,25 +2,29 @@
 
 set -e
 
+version=$(git describe --tags)
+sed -i "s/vDEVELOPMENT/$version/g" src/info.ts 
+
 # before we do anything else, ensure we typecheck fine
 deno task check
 
 cli_name="collie"
 deno_flags=$(deno run flags.ts --quiet)
 
-mkdir -p bin/unix bin/windows
+mkdir -p bin
 
 compile_unix(){
   target="$1"
 
-  deno compile $deno_flags --target "$target" --output "./bin/unix/$cli_name-$target" src/main.ts
+  deno compile $deno_flags --target "$target" --output "./bin/$cli_name-$target" src/main.ts
+  tar -czvf "./bin/$cli_name-$target.tar.gz" "./bin/$cli_name-$target"
 }
 
 compile_windows(){
   target="$1"
 
-  deno compile $deno_flags --target "$target" --output "./bin/windows/$cli_name-$target" src/main.ts
- 
+  deno compile $deno_flags --target "$target" --output "./bin/$cli_name-$target" src/main.ts
+  # we currently don't tar gz windows binaries to maintain compatibility with out install.ps1 script
 }
 
 compile_unix "x86_64-unknown-linux-gnu"

--- a/default.nix
+++ b/default.nix
@@ -11,6 +11,7 @@ pkgs.mkShell {
     
     # used for build scripts
     pkgs.unzip
+    pkgs.gnused
 
     # cloud provider clis
     pkgs.awscli2

--- a/src/info.ts
+++ b/src/info.ts
@@ -1,5 +1,8 @@
 // see https://stackoverflow.com/questions/61829367/node-js-dirname-filename-equivalent-in-deno
-export const VERSION = "0.16.0";
+
+// ATTENTION: DO NOT COMMIT CHANGES TO THIS VERSION STRING, it's replaced in build.sh when performing a release.
+// This should always have the value "vDEVELOPMENT"
+export const VERSION = "vDEVELOPMENT".substring(1);
 
 /**
  * The flags we want collie to be invoked with.


### PR DESCRIPTION
- run deno check and deno test in build workflow
- leave deno compile to the release workflow (we generally trust deno compile to not break if deno check passed)
- get rid of manually bumping version in info.ts

this should make it much smoother to create new collie releases