### PR TITLE
fix: kit apply must not generate output-md-file

### DIFF
--- a/src/commands/kit/kit-utilities.ts
+++ b/src/commands/kit/kit-utilities.ts
@@ -131,10 +131,17 @@ EOF
   source = "\${get_repo_root()}//${posixKitModulePath}"
 }`;
 
+  // The output_md_file variable must not be included in the generated code because it's being set on platform.hcl level
+  //  Setting output_md_file variable here leads to an error, because an empty path is used
+  // TODO Clean up once when reworking output paths
   const tfvars = await terraformDocs.generateTfvars(kitModulePath);
+  const tfvars_without_output_md = tfvars.replace(
+    /output_md_file\s*=\s*""\s*\n/,
+    "",
+  );
   const inputsBlock = `inputs = {
   # todo: set input variables
-${indent(tfvars, 2)}
+${indent(tfvars_without_output_md, 2)}
 }`;
 
   return [


### PR DESCRIPTION
This fixes collie kit apply
```
Error: Create local file error
│
│   with local_file.output_md,
│   on documentation.tf line 6, in resource "local_file" "output_md":
│    6: resource "local_file" "output_md" {
│
│ An unexpected error occurred while writing the file
│
│ +Original Error: open : no such file or directory
╵
```