### PR TITLE
feat: add a collie info command

### DIFF
--- a/src/commands/info.command.ts
+++ b/src/commands/info.command.ts
@@ -1,0 +1,47 @@
+import * as colors from "std/fmt/colors";
+
+import { CliApiFacadeFactory } from "../api/CliApiFacadeFactory.ts";
+import { CliDetectionResult } from "../api/CliDetector.ts";
+import { InstallationStatus } from "../api/CliInstallationStatus.ts";
+import { Logger } from "../cli/Logger.ts";
+import { CollieRepository } from "../model/CollieRepository.ts";
+import { TopLevelCommand } from "./TopLevelCommand.ts";
+import { GlobalCommandOptions } from "./GlobalCommandOptions.ts";
+
+export function registerInfoCommand(program: TopLevelCommand) {
+  program
+    .command("info")
+    .description("Show info about this program and the environment")
+    .action(async (opts: GlobalCommandOptions) => {
+      console.log("collie %s\n", program.getVersion());
+
+      console.log(`Runtime:`);
+      console.log(`deno ${Deno.version.deno} ${Deno.build.target}\n`);
+
+      const collie = new CollieRepository("./");
+      const logger = new Logger(collie, opts);
+
+      const factory = new CliApiFacadeFactory(collie, logger);
+
+      const detectors = factory.buildCliDetectors();
+
+      const detectTasks = detectors.map((x) => x.detect());
+      const infos = await Promise.all(detectTasks);
+
+      const cliInfos = infos.map((x) => formatInfo(x)).join("\n");
+      console.log("Installed dependencies:");
+      console.log(cliInfos);
+    });
+}
+
+function formatInfo(r: CliDetectionResult) {
+  switch (r.status) {
+    case InstallationStatus.NotInstalled:
+      return `${r.cli} ${colors.italic("not installed")}`;
+    case InstallationStatus.UnsupportedVersion:
+      return `${r.cli} ${r.version} ${colors.italic("unsupported version")}`;
+    case InstallationStatus.Installed: {
+      return `${r.cli} ${r.version}`;
+    }
+  }
+}

--- a/src/commands/version.command.ts
+++ b/src/commands/version.command.ts
@@ -1,43 +1,11 @@
-import * as colors from "std/fmt/colors";
-
-import { CliApiFacadeFactory } from "../api/CliApiFacadeFactory.ts";
-import { CliDetectionResult } from "../api/CliDetector.ts";
-import { InstallationStatus } from "../api/CliInstallationStatus.ts";
-import { Logger } from "../cli/Logger.ts";
-import { CollieRepository } from "../model/CollieRepository.ts";
 import { TopLevelCommand } from "./TopLevelCommand.ts";
 
 export function registerVersionCommand(program: TopLevelCommand) {
   program.versionOption(
     "-V, --version",
     "Show the version number for this program.",
-    async function () {
-      console.log("collie %s\n", program.getVersion());
-
-      const collie = new CollieRepository("./");
-      const logger = new Logger(collie, {});
-
-      const factory = new CliApiFacadeFactory(collie, logger);
-
-      const detectors = factory.buildCliDetectors();
-
-      const detectTasks = detectors.map((x) => x.detect());
-      const infos = await Promise.all(detectTasks);
-
-      const cliInfos = infos.map((x) => formatInfo(x)).join("\n");
-      console.log(cliInfos);
+    () => {
+      console.log("collie %s", program.getVersion());
     },
   );
-}
-
-function formatInfo(r: CliDetectionResult) {
-  switch (r.status) {
-    case InstallationStatus.NotInstalled:
-      return `${r.cli} ${colors.italic("not installed")}`;
-    case InstallationStatus.UnsupportedVersion:
-      return `${r.cli} ${r.version} ${colors.italic("unsupported version")}`;
-    case InstallationStatus.Installed: {
-      return `${r.cli} ${r.version}`;
-    }
-  }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,7 @@ import { registerVersionCommand } from "./commands/version.command.ts";
 import { FirstTimeExperience } from "./FirstTimeExperience.ts";
 import { CollieFoundationDoesNotExistError } from "./model/schemas/ModelValidator.ts";
 import { makeTopLevelCommand } from "./commands/TopLevelCommand.ts";
+import { registerInfoCommand } from "./commands/info.command.ts";
 
 async function collie() {
   const program = makeTopLevelCommand()
@@ -35,6 +36,7 @@ async function collie() {
   registerKitCommand(program);
   registerComplianceCommand(program);
 
+  registerInfoCommand(program);
   registerUpgradeCommand(program);
   registerVersionCommand(program);
 


### PR DESCRIPTION
This command now returns runtime and detected CLI version infos. The version command now outputs only the version number