### PR TITLE
feat: add red/green icons to collie info

### DIFF
--- a/src/commands/info.command.ts
+++ b/src/commands/info.command.ts
@@ -37,11 +37,13 @@ export function registerInfoCommand(program: TopLevelCommand) {
 function formatInfo(r: CliDetectionResult) {
   switch (r.status) {
     case InstallationStatus.NotInstalled:
-      return `${r.cli} ${colors.italic("not installed")}`;
+      return `${colors.red("x")} ${r.cli} ${colors.italic("not installed")}`;
     case InstallationStatus.UnsupportedVersion:
-      return `${r.cli} ${r.version} ${colors.italic("unsupported version")}`;
+      return `${colors.red("x")} ${r.cli} ${r.version} ${
+        colors.italic("unsupported version")
+      }`;
     case InstallationStatus.Installed: {
-      return `${r.cli} ${r.version}`;
+      return `${colors.green("✔")} ${r.cli} ${r.version}`;
     }
   }
 }


### PR DESCRIPTION
this improves clarity about installed/not installed dependencies

<img width="297" alt="image" src="https://github.com/meshcloud/collie-cli/assets/130103/7ee20496-7319-4b53-a106-45e02248abd2">
