### PR TITLE
Feature/collie config

### DIFF
--- a/src/cli/commandOptionsConventions.ts
+++ b/src/cli/commandOptionsConventions.ts
@@ -1,0 +1,14 @@
+import { InteractivePrompts } from "../commands/interactive/InteractivePrompts.ts";
+import { CollieRepository } from "../model/CollieRepository.ts";
+import { CollieConfig } from "../model/CollieConfig.ts";
+import { Logger } from "./Logger.ts";
+
+export async function getCurrentWorkingFoundation(
+  foundation: string | undefined,
+  logger: Logger,
+  repo: CollieRepository,
+): Promise<string> {
+  return foundation ||
+    CollieConfig.getFoundation(logger) ||
+    (await InteractivePrompts.selectFoundation(repo, logger));
+}

--- a/src/cli/commandOptionsConventions.ts
+++ b/src/cli/commandOptionsConventions.ts
@@ -3,12 +3,21 @@ import { CollieRepository } from "../model/CollieRepository.ts";
 import { CollieConfig } from "../model/CollieConfig.ts";
 import { Logger } from "./Logger.ts";
 
+/**
+ * Determine the foundation for a CLI command.
+ * Order of preference param foundation > config property foundation > interactive prompt
+ */
 export async function getCurrentWorkingFoundation(
   foundation: string | undefined,
   logger: Logger,
   repo: CollieRepository,
-): Promise<string> {
-  return foundation ||
-    CollieConfig.getFoundation(logger) ||
-    (await InteractivePrompts.selectFoundation(repo, logger));
+) {
+  if (foundation) {
+    return foundation;
+  } else {
+    const config = new CollieConfig(repo, logger);
+
+    return config.getProperty("foundation") ||
+      (await InteractivePrompts.selectFoundation(repo, logger));
+  }
 }

--- a/src/commands/config/config.command.ts
+++ b/src/commands/config/config.command.ts
@@ -1,6 +1,5 @@
-import { TopLevelCommand, makeTopLevelCommand } from "../TopLevelCommand.ts";
+import { makeTopLevelCommand, TopLevelCommand } from "../TopLevelCommand.ts";
 import { registerSetCmd } from "./set.command.ts";
-import { CLI } from "../../info.ts";
 
 export function registerConfigCommand(program: TopLevelCommand) {
   const configCommand = makeTopLevelCommand();
@@ -9,11 +8,7 @@ export function registerConfigCommand(program: TopLevelCommand) {
   program
     .command("config", configCommand)
     .description(
-      "View and edit collie repository config."
-  )
-    .example(
-      "Set foundation `myfoundation-dev` in repository config.",
-      `${CLI} config set foundation myfoundation-dev`,
+      "View and edit collie repository config.",
     )
     .action(() => configCommand.showHelp());
 }

--- a/src/commands/config/config.command.ts
+++ b/src/commands/config/config.command.ts
@@ -1,9 +1,11 @@
 import { makeTopLevelCommand, TopLevelCommand } from "../TopLevelCommand.ts";
 import { registerSetCmd } from "./set.command.ts";
+import { registerGetCmd } from "./get.command.ts";
 
 export function registerConfigCommand(program: TopLevelCommand) {
   const configCommand = makeTopLevelCommand();
   registerSetCmd(configCommand);
+  registerGetCmd(configCommand);
 
   program
     .command("config", configCommand)

--- a/src/commands/config/config.command.ts
+++ b/src/commands/config/config.command.ts
@@ -1,0 +1,19 @@
+import { TopLevelCommand, makeTopLevelCommand } from "../TopLevelCommand.ts";
+import { registerSetCmd } from "./set.command.ts";
+import { CLI } from "../../info.ts";
+
+export function registerConfigCommand(program: TopLevelCommand) {
+  const configCommand = makeTopLevelCommand();
+  registerSetCmd(configCommand);
+
+  program
+    .command("config", configCommand)
+    .description(
+      "View and edit collie repository config."
+  )
+    .example(
+      "Set foundation `myfoundation-dev` in repository config.",
+      `${CLI} config set foundation myfoundation-dev`,
+    )
+    .action(() => configCommand.showHelp());
+}

--- a/src/commands/config/get.command.ts
+++ b/src/commands/config/get.command.ts
@@ -1,0 +1,25 @@
+import { GlobalCommandOptions } from "../GlobalCommandOptions.ts";
+import { TopLevelCommand } from "../TopLevelCommand.ts";
+import { CollieConfig } from "../../model/CollieConfig.ts";
+import { Logger } from "../../cli/Logger.ts";
+import { CollieRepository } from "../../model/CollieRepository.ts";
+import { CLI } from "../../info.ts";
+
+export function registerGetCmd(program: TopLevelCommand) {
+  program
+    .command("get <property>")
+    .description("Get a config property from the repository config.")
+    .example(
+      "Get foundation property from repository config",
+      `${CLI} config get foundation`,
+    )
+    .action(
+      async (opts: GlobalCommandOptions, property: string) => {
+        const repo = await CollieRepository.load();
+        const logger = new Logger(repo, opts);
+        const config = new CollieConfig(repo, logger);
+        const value = config.getProperty(property);
+        console.log(value);
+      },
+    );
+}

--- a/src/commands/config/set.command.ts
+++ b/src/commands/config/set.command.ts
@@ -11,17 +11,18 @@ export function registerSetCmd(program: TopLevelCommand) {
     .command("set-foundation [foundation:foundation]")
     .description("Set the foundation config property.")
     .example(
-      "Set foundation `myfoundation` in repository config.",
+      "Set foundation `myfoundation` in repository config",
       `${CLI} config set-foundation myfoundation`,
     )
     .action(
       async (opts: GlobalCommandOptions, foundationArg: string | undefined) => {
-        const collieRepo = await CollieRepository.load();
-        const logger = new Logger(collieRepo, opts);
+        const repo = await CollieRepository.load();
+        const logger = new Logger(repo, opts);
         const foundation = foundationArg ||
-          (await InteractivePrompts.selectFoundation(collieRepo, logger));
+          (await InteractivePrompts.selectFoundation(repo, logger));
 
-        CollieConfig.setFoundation(foundation, logger);
+        const config = new CollieConfig(repo, logger);
+        config.setProperty("foundation", foundation);
       },
     );
 }

--- a/src/commands/config/set.command.ts
+++ b/src/commands/config/set.command.ts
@@ -21,22 +21,7 @@ export function registerSetCmd(program: TopLevelCommand) {
         const foundation = foundationArg ||
           (await InteractivePrompts.selectFoundation(collieRepo, logger));
 
-        setFoundation(foundation, logger);
+        CollieConfig.setFoundation(foundation, logger);
       },
     );
-}
-
-export function setFoundation(
-  foundation: string,
-  logger: Logger,
-) {
-  // this replaces the file as a whole (unsetting all other options)
-  //TODO  read file and replace value
-  Deno.writeTextFile(
-    CollieConfig.CONFIG_FILE_PATH,
-    JSON.stringify({ "foundation": foundation }),
-  );
-  logger.progress(
-    `set current foundation to ${foundation} in ${CollieConfig.CONFIG_FILE_PATH}`,
-  );
 }

--- a/src/commands/config/set.command.ts
+++ b/src/commands/config/set.command.ts
@@ -8,7 +8,7 @@ import { CLI } from "../../info.ts";
 
 export function registerSetCmd(program: TopLevelCommand) {
   program
-    .command("set-foundation <foundation:foundation>")
+    .command("set-foundation [foundation:foundation]")
     .description("Set the foundation config property.")
     .example(
       "Set foundation `myfoundation` in repository config.",

--- a/src/commands/config/set.command.ts
+++ b/src/commands/config/set.command.ts
@@ -1,20 +1,42 @@
 import { GlobalCommandOptions } from "../GlobalCommandOptions.ts";
-import { TopLevelCommand, makeTopLevelCommand } from "../TopLevelCommand.ts";
+import { TopLevelCommand } from "../TopLevelCommand.ts";
 import { CollieConfig } from "../../model/CollieConfig.ts";
 import { Logger } from "../../cli/Logger.ts";
 import { CollieRepository } from "../../model/CollieRepository.ts";
+import { InteractivePrompts } from "../interactive/InteractivePrompts.ts";
+import { CLI } from "../../info.ts";
 
 export function registerSetCmd(program: TopLevelCommand) {
   program
     .command("set-foundation <foundation:foundation>")
     .description("Set the foundation config property.")
-    .action(async (opts: GlobalCommandOptions, foundation: string) => {
+    .example(
+      "Set foundation `myfoundation` in repository config.",
+      `${CLI} config set-foundation myfoundation`,
+    )
+    .action(
+      async (opts: GlobalCommandOptions, foundationArg: string | undefined) => {
+        const collieRepo = await CollieRepository.load();
+        const logger = new Logger(collieRepo, opts);
+        const foundation = foundationArg ||
+          (await InteractivePrompts.selectFoundation(collieRepo, logger));
 
-      const collieRepo = await CollieRepository.load();
-      const logger = new Logger(collieRepo, opts);
-      // this replaces the file as a whole (unsetting all other options)
-      //TODO  read file and replace value
-      Deno.writeTextFile(CollieConfig.CONFIG_FILE_PATH, JSON.stringify({ "foundation": foundation })); 
-      logger.progress(`Set foundation to ${foundation}`)
-    })
-} 
+        setFoundation(foundation, logger);
+      },
+    );
+}
+
+export function setFoundation(
+  foundation: string,
+  logger: Logger,
+) {
+  // this replaces the file as a whole (unsetting all other options)
+  //TODO  read file and replace value
+  Deno.writeTextFile(
+    CollieConfig.CONFIG_FILE_PATH,
+    JSON.stringify({ "foundation": foundation }),
+  );
+  logger.progress(
+    `set current foundation to ${foundation} in ${CollieConfig.CONFIG_FILE_PATH}`,
+  );
+}

--- a/src/commands/config/set.command.ts
+++ b/src/commands/config/set.command.ts
@@ -5,12 +5,11 @@ const CONFIG_FILE_PATH = ".collie/config.json";
 
 export function registerSetCmd(program: TopLevelCommand) {
   program
-    .command("set <property> <value>")
-    .description("Set a collie CLI property.")
-    .action((_opts: GlobalCommandOptions, property: string, value: string) => {
+    .command("set-foundation <foundation:foundation>")
+    .description("Set the foundation config property.")
+    .action((_opts: GlobalCommandOptions, foundation: string) => {
       // this replaces the file as a whole (unsetting all other options)
       //TODO  read file and replace value
-      //TODO check if property is valid
-      //TODO auto-complete foundation
+      Deno.writeTextFile(CONFIG_FILE_PATH, JSON.stringify({ "foundation": foundation })); 
     })
 } 

--- a/src/commands/config/set.command.ts
+++ b/src/commands/config/set.command.ts
@@ -1,15 +1,20 @@
 import { GlobalCommandOptions } from "../GlobalCommandOptions.ts";
 import { TopLevelCommand, makeTopLevelCommand } from "../TopLevelCommand.ts";
-
-const CONFIG_FILE_PATH = ".collie/config.json";
+import { CollieConfig } from "../../model/CollieConfig.ts";
+import { Logger } from "../../cli/Logger.ts";
+import { CollieRepository } from "../../model/CollieRepository.ts";
 
 export function registerSetCmd(program: TopLevelCommand) {
   program
     .command("set-foundation <foundation:foundation>")
     .description("Set the foundation config property.")
-    .action((_opts: GlobalCommandOptions, foundation: string) => {
+    .action(async (opts: GlobalCommandOptions, foundation: string) => {
+
+      const collieRepo = await CollieRepository.load();
+      const logger = new Logger(collieRepo, opts);
       // this replaces the file as a whole (unsetting all other options)
       //TODO  read file and replace value
-      Deno.writeTextFile(CONFIG_FILE_PATH, JSON.stringify({ "foundation": foundation })); 
+      Deno.writeTextFile(CollieConfig.CONFIG_FILE_PATH, JSON.stringify({ "foundation": foundation })); 
+      logger.progress(`Set foundation to ${foundation}`)
     })
 } 

--- a/src/commands/config/set.command.ts
+++ b/src/commands/config/set.command.ts
@@ -1,0 +1,16 @@
+import { GlobalCommandOptions } from "../GlobalCommandOptions.ts";
+import { TopLevelCommand, makeTopLevelCommand } from "../TopLevelCommand.ts";
+
+const CONFIG_FILE_PATH = ".collie/config.json";
+
+export function registerSetCmd(program: TopLevelCommand) {
+  program
+    .command("set <property> <value>")
+    .description("Set a collie CLI property.")
+    .action((_opts: GlobalCommandOptions, property: string, value: string) => {
+      // this replaces the file as a whole (unsetting all other options)
+      //TODO  read file and replace value
+      //TODO check if property is valid
+      //TODO auto-complete foundation
+    })
+} 

--- a/src/commands/foundation/deploy.command.ts
+++ b/src/commands/foundation/deploy.command.ts
@@ -15,8 +15,7 @@ import { PlatformModuleType } from "./PlatformModuleType.ts";
 import { CLI } from "../../info.ts";
 import { LiteralArgsParser } from "../LiteralArgsParser.ts";
 import { TopLevelCommand } from "../TopLevelCommand.ts";
-import { InteractivePrompts } from "../interactive/InteractivePrompts.ts";
-import { CollieConfig } from "../../model/CollieConfig.ts";
+import { getCurrentWorkingFoundation } from "../../cli/commandOptionsConventions.ts";
 
 interface DeployOptions {
   platform?: string;
@@ -81,9 +80,11 @@ export function registerDeployCmd(program: TopLevelCommand) {
 
         const mode = { raw: literalArgs.length ? literalArgs : ["apply"] };
 
-        const foundation = foundationArg ||
-          CollieConfig.getFoundation(logger) ||
-          (await InteractivePrompts.selectFoundation(collieRepo, logger));
+        const foundation = await getCurrentWorkingFoundation(
+          foundationArg,
+          logger,
+          collieRepo,
+        );
 
         const foundationProgress = opts.platform
           ? new NullProgressReporter()

--- a/src/commands/foundation/deploy.command.ts
+++ b/src/commands/foundation/deploy.command.ts
@@ -71,7 +71,7 @@ export function registerDeployCmd(program: TopLevelCommand) {
     .action(
       async (
         opts: DeployOptions & GlobalCommandOptions,
-        foundationArg: string|undefined,
+        foundationArg: string | undefined,
       ) => {
         const literalArgs = LiteralArgsParser.parse(cmd.getRawArgs());
 
@@ -81,8 +81,8 @@ export function registerDeployCmd(program: TopLevelCommand) {
 
         const mode = { raw: literalArgs.length ? literalArgs : ["apply"] };
 
-        const foundation = foundationArg || 
-          CollieConfig.read_foundation(logger) ||
+        const foundation = foundationArg ||
+          CollieConfig.getFoundation(logger) ||
           (await InteractivePrompts.selectFoundation(collieRepo, logger));
 
         const foundationProgress = opts.platform

--- a/src/commands/foundation/docs.command.ts
+++ b/src/commands/foundation/docs.command.ts
@@ -15,6 +15,8 @@ import { FoundationRepository } from "../../model/FoundationRepository.ts";
 import { ModelValidator } from "../../model/schemas/ModelValidator.ts";
 import { GlobalCommandOptions } from "../GlobalCommandOptions.ts";
 import { TopLevelCommand } from "../TopLevelCommand.ts";
+import { InteractivePrompts } from "../interactive/InteractivePrompts.ts";
+import { CollieConfig } from "../../model/CollieConfig.ts";
 
 interface DocsCommandOptions {
   update?: boolean;
@@ -23,18 +25,22 @@ interface DocsCommandOptions {
 
 export function registerDocsCmd(program: TopLevelCommand) {
   program
-    .command("docs <foundation:foundation>")
+    .command("docs [foundation:foundation]")
     .description(
       "Generate end-user friendly documentation for your cloud foundation",
     )
     .action(
       async (
         opts: GlobalCommandOptions & DocsCommandOptions,
-        foundation: string,
+        foundationArg: string|undefined,
       ) => {
         const repo = await CollieRepository.load();
         const logger = new Logger(repo, opts);
         const validator = new ModelValidator(logger);
+
+        const foundation = foundationArg || 
+          CollieConfig.read_foundation(logger) ||
+          (await InteractivePrompts.selectFoundation(repo, logger));
 
         const foundationRepo = await FoundationRepository.load(
           repo,

--- a/src/commands/foundation/docs.command.ts
+++ b/src/commands/foundation/docs.command.ts
@@ -32,14 +32,14 @@ export function registerDocsCmd(program: TopLevelCommand) {
     .action(
       async (
         opts: GlobalCommandOptions & DocsCommandOptions,
-        foundationArg: string|undefined,
+        foundationArg: string | undefined,
       ) => {
         const repo = await CollieRepository.load();
         const logger = new Logger(repo, opts);
         const validator = new ModelValidator(logger);
 
-        const foundation = foundationArg || 
-          CollieConfig.read_foundation(logger) ||
+        const foundation = foundationArg ||
+          CollieConfig.getFoundation(logger) ||
           (await InteractivePrompts.selectFoundation(repo, logger));
 
         const foundationRepo = await FoundationRepository.load(

--- a/src/commands/foundation/docs.command.ts
+++ b/src/commands/foundation/docs.command.ts
@@ -15,8 +15,7 @@ import { FoundationRepository } from "../../model/FoundationRepository.ts";
 import { ModelValidator } from "../../model/schemas/ModelValidator.ts";
 import { GlobalCommandOptions } from "../GlobalCommandOptions.ts";
 import { TopLevelCommand } from "../TopLevelCommand.ts";
-import { InteractivePrompts } from "../interactive/InteractivePrompts.ts";
-import { CollieConfig } from "../../model/CollieConfig.ts";
+import { getCurrentWorkingFoundation } from "../../cli/commandOptionsConventions.ts";
 
 interface DocsCommandOptions {
   update?: boolean;
@@ -38,9 +37,11 @@ export function registerDocsCmd(program: TopLevelCommand) {
         const logger = new Logger(repo, opts);
         const validator = new ModelValidator(logger);
 
-        const foundation = foundationArg ||
-          CollieConfig.getFoundation(logger) ||
-          (await InteractivePrompts.selectFoundation(repo, logger));
+        const foundation = await getCurrentWorkingFoundation(
+          foundationArg,
+          logger,
+          repo,
+        );
 
         const foundationRepo = await FoundationRepository.load(
           repo,

--- a/src/commands/foundation/new.command.ts
+++ b/src/commands/foundation/new.command.ts
@@ -56,7 +56,9 @@ export function registerNewCmd(program: TopLevelCommand) {
       logger.progress(
         "generated new foundation at " + repo.relativePath(foundationPath),
       );
-      CollieConfig.setFoundation(foundation, logger);
+
+      const config = new CollieConfig(repo, logger);
+      config.setProperty("foundation", foundation);
     });
 }
 

--- a/src/commands/foundation/new.command.ts
+++ b/src/commands/foundation/new.command.ts
@@ -17,7 +17,7 @@ import { PlatformSetup } from "../../api/PlatformSetup.ts";
 import { MeshError } from "../../errors.ts";
 import { CLI } from "../../info.ts";
 import { TopLevelCommand } from "../TopLevelCommand.ts";
-import { setFoundation } from "../config/set.command.ts";
+import { CollieConfig } from "../../model/CollieConfig.ts";
 
 export function registerNewCmd(program: TopLevelCommand) {
   program
@@ -56,7 +56,7 @@ export function registerNewCmd(program: TopLevelCommand) {
       logger.progress(
         "generated new foundation at " + repo.relativePath(foundationPath),
       );
-      setFoundation(foundation, logger);
+      CollieConfig.setFoundation(foundation, logger);
     });
 }
 

--- a/src/commands/foundation/new.command.ts
+++ b/src/commands/foundation/new.command.ts
@@ -17,6 +17,7 @@ import { PlatformSetup } from "../../api/PlatformSetup.ts";
 import { MeshError } from "../../errors.ts";
 import { CLI } from "../../info.ts";
 import { TopLevelCommand } from "../TopLevelCommand.ts";
+import { setFoundation } from "../config/set.command.ts";
 
 export function registerNewCmd(program: TopLevelCommand) {
   program
@@ -55,6 +56,7 @@ export function registerNewCmd(program: TopLevelCommand) {
       logger.progress(
         "generated new foundation at " + repo.relativePath(foundationPath),
       );
+      setFoundation(foundation, logger);
     });
 }
 

--- a/src/commands/interactive/InteractivePrompts.ts
+++ b/src/commands/interactive/InteractivePrompts.ts
@@ -4,9 +4,14 @@ import { isWindows } from "../../os.ts";
 import { CollieRepository } from "../../model/CollieRepository.ts";
 import { FoundationRepository } from "../../model/FoundationRepository.ts";
 import { KitModuleRepository } from "../../kit/KitModuleRepository.ts";
+import { Logger } from "../../cli/Logger.ts";
 
 export class InteractivePrompts {
-  static async selectFoundation(kit: CollieRepository) {
+  static async selectFoundation(kit: CollieRepository, logger: Logger) {
+    logger.tipCommand(
+      `To set a default foundation run`,
+      `config set-foundation"`,
+    );
     return await Select.prompt({
       message: "Select a foundation",
       options: (

--- a/src/commands/interactive/InteractivePrompts.ts
+++ b/src/commands/interactive/InteractivePrompts.ts
@@ -10,7 +10,7 @@ export class InteractivePrompts {
   static async selectFoundation(kit: CollieRepository, logger: Logger) {
     logger.tipCommand(
       `To set a default foundation run`,
-      `config set-foundation"`,
+      `config set-foundation <foundation>"`,
     );
     return await Select.prompt({
       message: "Select a foundation",

--- a/src/commands/kit/apply.command.ts
+++ b/src/commands/kit/apply.command.ts
@@ -16,6 +16,7 @@ import { CommandOptionError } from "../CommandOptionError.ts";
 import { TopLevelCommand } from "../TopLevelCommand.ts";
 import { generateTerragrunt } from "./kit-utilities.ts";
 import { CliApiFacadeFactory } from "../../api/CliApiFacadeFactory.ts";
+import { CollieConfig } from "../../model/CollieConfig.ts";
 
 interface ApplyOptions {
   foundation?: string;
@@ -53,7 +54,8 @@ export function registerApplyCmd(program: TopLevelCommand) {
         }
 
         const foundation = opts.foundation ||
-          (await InteractivePrompts.selectFoundation(collie));
+          CollieConfig.read_foundation(logger) ||
+          (await InteractivePrompts.selectFoundation(collie, logger));
 
         const foundationRepo = await FoundationRepository.load(
           collie,

--- a/src/commands/kit/apply.command.ts
+++ b/src/commands/kit/apply.command.ts
@@ -54,7 +54,7 @@ export function registerApplyCmd(program: TopLevelCommand) {
         }
 
         const foundation = opts.foundation ||
-          CollieConfig.read_foundation(logger) ||
+          CollieConfig.getFoundation(logger) ||
           (await InteractivePrompts.selectFoundation(collie, logger));
 
         const foundationRepo = await FoundationRepository.load(

--- a/src/commands/kit/apply.command.ts
+++ b/src/commands/kit/apply.command.ts
@@ -16,7 +16,7 @@ import { CommandOptionError } from "../CommandOptionError.ts";
 import { TopLevelCommand } from "../TopLevelCommand.ts";
 import { generateTerragrunt } from "./kit-utilities.ts";
 import { CliApiFacadeFactory } from "../../api/CliApiFacadeFactory.ts";
-import { CollieConfig } from "../../model/CollieConfig.ts";
+import { getCurrentWorkingFoundation } from "../../cli/commandOptionsConventions.ts";
 
 interface ApplyOptions {
   foundation?: string;
@@ -34,7 +34,7 @@ export function registerApplyCmd(program: TopLevelCommand) {
     )
     .action(
       async (opts: GlobalCommandOptions & ApplyOptions, moduleId?: string) => {
-        const collie = new CollieRepository("./");
+        const collie = await CollieRepository.load();
         const logger = new Logger(collie, opts);
         const validator = new ModelValidator(logger);
 
@@ -53,9 +53,11 @@ export function registerApplyCmd(program: TopLevelCommand) {
           );
         }
 
-        const foundation = opts.foundation ||
-          CollieConfig.getFoundation(logger) ||
-          (await InteractivePrompts.selectFoundation(collie, logger));
+        const foundation = await getCurrentWorkingFoundation(
+          opts.foundation,
+          logger,
+          collie,
+        );
 
         const foundationRepo = await FoundationRepository.load(
           collie,

--- a/src/commands/kit/bundle.command.ts
+++ b/src/commands/kit/bundle.command.ts
@@ -27,7 +27,6 @@ import * as path from "std/path";
 import { Toggle } from "x/cliffy/prompt";
 import { indent } from "../../cli/indent.ts";
 import { applyKitModule } from "./apply.command.ts";
-import { CollieConfig } from "../../model/CollieConfig.ts";
 import { getCurrentWorkingFoundation } from "../../cli/commandOptionsConventions.ts";
 
 function availableKitBundles(locations: AzLocation[]): KitBundle[] {

--- a/src/commands/kit/bundle.command.ts
+++ b/src/commands/kit/bundle.command.ts
@@ -27,6 +27,7 @@ import * as path from "std/path";
 import { Toggle } from "x/cliffy/prompt";
 import { indent } from "../../cli/indent.ts";
 import { applyKitModule } from "./apply.command.ts";
+import { CollieConfig } from "../../model/CollieConfig.ts";
 
 function availableKitBundles(locations: AzLocation[]): KitBundle[] {
   return [
@@ -60,7 +61,8 @@ export function registerBundledKitCmd(program: TopLevelCommand) {
         const validator = new ModelValidator(logger);
 
         const foundation = opts.foundation ||
-          (await InteractivePrompts.selectFoundation(collie));
+          CollieConfig.read_foundation(logger) ||
+          (await InteractivePrompts.selectFoundation(collie, logger));
 
         const foundationRepo = await FoundationRepository.load(
           collie,

--- a/src/commands/kit/bundle.command.ts
+++ b/src/commands/kit/bundle.command.ts
@@ -61,7 +61,7 @@ export function registerBundledKitCmd(program: TopLevelCommand) {
         const validator = new ModelValidator(logger);
 
         const foundation = opts.foundation ||
-          CollieConfig.read_foundation(logger) ||
+          CollieConfig.getFoundation(logger) ||
           (await InteractivePrompts.selectFoundation(collie, logger));
 
         const foundationRepo = await FoundationRepository.load(

--- a/src/commands/kit/bundle.command.ts
+++ b/src/commands/kit/bundle.command.ts
@@ -28,6 +28,7 @@ import { Toggle } from "x/cliffy/prompt";
 import { indent } from "../../cli/indent.ts";
 import { applyKitModule } from "./apply.command.ts";
 import { CollieConfig } from "../../model/CollieConfig.ts";
+import { getCurrentWorkingFoundation } from "../../cli/commandOptionsConventions.ts";
 
 function availableKitBundles(locations: AzLocation[]): KitBundle[] {
   return [
@@ -60,9 +61,11 @@ export function registerBundledKitCmd(program: TopLevelCommand) {
         const logger = new Logger(collie, opts);
         const validator = new ModelValidator(logger);
 
-        const foundation = opts.foundation ||
-          CollieConfig.getFoundation(logger) ||
-          (await InteractivePrompts.selectFoundation(collie, logger));
+        const foundation = await getCurrentWorkingFoundation(
+          opts.foundation,
+          logger,
+          collie,
+        );
 
         const foundationRepo = await FoundationRepository.load(
           collie,

--- a/src/commands/tenant/analyze-tag.command.ts
+++ b/src/commands/tenant/analyze-tag.command.ts
@@ -41,15 +41,14 @@ async function analyzeTagsAction(
     & GlobalCommandOptions
     & TenantCommandOptions
     & AnalyzeTagsCommandOptions,
-  foundationArg: string|undefined,
+  foundationArg: string | undefined,
 ) {
-
   const repo = await CollieRepository.load();
   const logger = new Logger(repo, options);
-  
-  const foundation = foundationArg || 
-  CollieConfig.read_foundation(logger) ||
-  (await InteractivePrompts.selectFoundation(repo, logger));
+
+  const foundation = foundationArg ||
+    CollieConfig.getFoundation(logger) ||
+    (await InteractivePrompts.selectFoundation(repo, logger));
 
   const { meshAdapter } = await prepareTenantCommand(options, foundation);
 

--- a/src/commands/tenant/analyze-tag.command.ts
+++ b/src/commands/tenant/analyze-tag.command.ts
@@ -6,10 +6,9 @@ import { MeshTenant } from "../../mesh/MeshTenantModel.ts";
 import { TenantCommandOptions } from "./TenantCommandOptions.ts";
 import { prepareTenantCommand } from "./prepareTenantCommand.ts";
 import { TenantCommand } from "./TenantCommand.ts";
-import { CollieConfig } from "../../model/CollieConfig.ts";
-import { InteractivePrompts } from "../interactive/InteractivePrompts.ts";
 import { Logger } from "../../cli/Logger.ts";
 import { CollieRepository } from "../../model/CollieRepository.ts";
+import { getCurrentWorkingFoundation } from "../../cli/commandOptionsConventions.ts";
 
 export function registerAnalyzeTagCommand(program: TenantCommand) {
   program
@@ -46,9 +45,11 @@ async function analyzeTagsAction(
   const repo = await CollieRepository.load();
   const logger = new Logger(repo, options);
 
-  const foundation = foundationArg ||
-    CollieConfig.getFoundation(logger) ||
-    (await InteractivePrompts.selectFoundation(repo, logger));
+  const foundation = await getCurrentWorkingFoundation(
+    foundationArg,
+    logger,
+    repo,
+  );
 
   const { meshAdapter } = await prepareTenantCommand(options, foundation);
 

--- a/src/commands/tenant/cost.command.ts
+++ b/src/commands/tenant/cost.command.ts
@@ -11,6 +11,7 @@ import { CollieConfig } from "../../model/CollieConfig.ts";
 import { InteractivePrompts } from "../interactive/InteractivePrompts.ts";
 import { Logger } from "../../cli/Logger.ts";
 import { CollieRepository } from "../../model/CollieRepository.ts";
+import { getCurrentWorkingFoundation } from "../../cli/commandOptionsConventions.ts";
 
 interface ListCostsCommandOptions extends GlobalCommandOptions, OutputOptions {
   from: string;
@@ -50,9 +51,11 @@ export async function listTenantsCostAction(
   const repo = await CollieRepository.load();
   const logger = new Logger(repo, options);
 
-  const foundation = foundationArg ||
-    CollieConfig.getFoundation(logger) ||
-    (await InteractivePrompts.selectFoundation(repo, logger));
+  const foundation = await getCurrentWorkingFoundation(
+    foundationArg,
+    logger,
+    repo,
+  );
 
   const { meshAdapter, tableFactory, queryStatistics } =
     await prepareTenantCommand(options, foundation);

--- a/src/commands/tenant/cost.command.ts
+++ b/src/commands/tenant/cost.command.ts
@@ -45,17 +45,15 @@ export async function listTenantsCostAction(
     & GlobalCommandOptions
     & TenantCommandOptions
     & ListCostsCommandOptions,
-  foundationArg: string|undefined,
+  foundationArg: string | undefined,
 ) {
-
-
   const repo = await CollieRepository.load();
   const logger = new Logger(repo, options);
-  
-  const foundation = foundationArg || 
-  CollieConfig.read_foundation(logger) ||
+
+  const foundation = foundationArg ||
+    CollieConfig.getFoundation(logger) ||
     (await InteractivePrompts.selectFoundation(repo, logger));
-  
+
   const { meshAdapter, tableFactory, queryStatistics } =
     await prepareTenantCommand(options, foundation);
 

--- a/src/commands/tenant/cost.command.ts
+++ b/src/commands/tenant/cost.command.ts
@@ -7,8 +7,6 @@ import { TenantCommandOptions } from "./TenantCommandOptions.ts";
 import { prepareTenantCommand } from "./prepareTenantCommand.ts";
 import { OutputFormat } from "../../presentation/output-format.ts";
 import { OutputOptions, TenantCommand } from "./TenantCommand.ts";
-import { CollieConfig } from "../../model/CollieConfig.ts";
-import { InteractivePrompts } from "../interactive/InteractivePrompts.ts";
 import { Logger } from "../../cli/Logger.ts";
 import { CollieRepository } from "../../model/CollieRepository.ts";
 import { getCurrentWorkingFoundation } from "../../cli/commandOptionsConventions.ts";

--- a/src/commands/tenant/iam.command.ts
+++ b/src/commands/tenant/iam.command.ts
@@ -45,13 +45,13 @@ export function registerIamCommand(program: TenantCommand) {
 
 async function listIamAction(
   options: GlobalCommandOptions & TenantCommandOptions & IamCommandOptions,
-  foundationArg: string|undefined,
+  foundationArg: string | undefined,
 ) {
   const repo = await CollieRepository.load();
   const logger = new Logger(repo, options);
-  
-  const foundation = foundationArg || 
-    CollieConfig.read_foundation(logger) ||
+
+  const foundation = foundationArg ||
+    CollieConfig.getFoundation(logger) ||
     (await InteractivePrompts.selectFoundation(repo, logger));
 
   const { meshAdapter, tableFactory } = await prepareTenantCommand(

--- a/src/commands/tenant/iam.command.ts
+++ b/src/commands/tenant/iam.command.ts
@@ -7,10 +7,9 @@ import { prepareTenantCommand } from "./prepareTenantCommand.ts";
 import { TenantCommandOptions } from "./TenantCommandOptions.ts";
 import { OutputFormat } from "../../presentation/output-format.ts";
 import { OutputOptions, TenantCommand } from "./TenantCommand.ts";
-import { CollieConfig } from "../../model/CollieConfig.ts";
-import { InteractivePrompts } from "../interactive/InteractivePrompts.ts";
 import { Logger } from "../../cli/Logger.ts";
 import { CollieRepository } from "../../model/CollieRepository.ts";
+import { getCurrentWorkingFoundation } from "../../cli/commandOptionsConventions.ts";
 
 interface IamCommandOptions extends OutputOptions, GlobalCommandOptions {
   includeAncestors?: boolean;
@@ -50,9 +49,11 @@ async function listIamAction(
   const repo = await CollieRepository.load();
   const logger = new Logger(repo, options);
 
-  const foundation = foundationArg ||
-    CollieConfig.getFoundation(logger) ||
-    (await InteractivePrompts.selectFoundation(repo, logger));
+  const foundation = await getCurrentWorkingFoundation(
+    foundationArg,
+    logger,
+    repo,
+  );
 
   const { meshAdapter, tableFactory } = await prepareTenantCommand(
     options,

--- a/src/commands/tenant/list.command.ts
+++ b/src/commands/tenant/list.command.ts
@@ -23,15 +23,15 @@ export function registerListCommand(program: TenantCommand) {
 
 export async function listTenantAction(
   options: TenantCommandOptions & GlobalCommandOptions & OutputOptions,
-  foundationArg: string|undefined,
+  foundationArg: string | undefined,
 ) {
   const repo = await CollieRepository.load();
   const logger = new Logger(repo, options);
-  
-  const foundation = foundationArg || 
-    CollieConfig.read_foundation(logger) ||
+
+  const foundation = foundationArg ||
+    CollieConfig.getFoundation(logger) ||
     (await InteractivePrompts.selectFoundation(repo, logger));
-  
+
   const { meshAdapter, tableFactory, queryStatistics } =
     await prepareTenantCommand(options, foundation);
 

--- a/src/commands/tenant/list.command.ts
+++ b/src/commands/tenant/list.command.ts
@@ -4,10 +4,9 @@ import { prepareTenantCommand } from "./prepareTenantCommand.ts";
 import { TenantCommandOptions } from "./TenantCommandOptions.ts";
 import { OutputFormat } from "../../presentation/output-format.ts";
 import { OutputOptions, TenantCommand } from "./TenantCommand.ts";
-import { CollieConfig } from "../../model/CollieConfig.ts";
-import { InteractivePrompts } from "../interactive/InteractivePrompts.ts";
 import { Logger } from "../../cli/Logger.ts";
 import { CollieRepository } from "../../model/CollieRepository.ts";
+import { getCurrentWorkingFoundation } from "../../cli/commandOptionsConventions.ts";
 
 export function registerListCommand(program: TenantCommand) {
   program
@@ -28,9 +27,11 @@ export async function listTenantAction(
   const repo = await CollieRepository.load();
   const logger = new Logger(repo, options);
 
-  const foundation = foundationArg ||
-    CollieConfig.getFoundation(logger) ||
-    (await InteractivePrompts.selectFoundation(repo, logger));
+  const foundation = await getCurrentWorkingFoundation(
+    foundationArg,
+    logger,
+    repo,
+  );
 
   const { meshAdapter, tableFactory, queryStatistics } =
     await prepareTenantCommand(options, foundation);

--- a/src/commands/tenant/list.command.ts
+++ b/src/commands/tenant/list.command.ts
@@ -4,10 +4,14 @@ import { prepareTenantCommand } from "./prepareTenantCommand.ts";
 import { TenantCommandOptions } from "./TenantCommandOptions.ts";
 import { OutputFormat } from "../../presentation/output-format.ts";
 import { OutputOptions, TenantCommand } from "./TenantCommand.ts";
+import { CollieConfig } from "../../model/CollieConfig.ts";
+import { InteractivePrompts } from "../interactive/InteractivePrompts.ts";
+import { Logger } from "../../cli/Logger.ts";
+import { CollieRepository } from "../../model/CollieRepository.ts";
 
 export function registerListCommand(program: TenantCommand) {
   program
-    .command("list <foundation:foundation>")
+    .command("list [foundation:foundation]")
     .option("-o, --output <output:output>", "Defines the output format", {
       default: OutputFormat.TABLE,
     })
@@ -19,8 +23,15 @@ export function registerListCommand(program: TenantCommand) {
 
 export async function listTenantAction(
   options: TenantCommandOptions & GlobalCommandOptions & OutputOptions,
-  foundation: string,
+  foundationArg: string|undefined,
 ) {
+  const repo = await CollieRepository.load();
+  const logger = new Logger(repo, options);
+  
+  const foundation = foundationArg || 
+    CollieConfig.read_foundation(logger) ||
+    (await InteractivePrompts.selectFoundation(repo, logger));
+  
   const { meshAdapter, tableFactory, queryStatistics } =
     await prepareTenantCommand(options, foundation);
 

--- a/src/commands/tenant/set-missing-tag.command.ts
+++ b/src/commands/tenant/set-missing-tag.command.ts
@@ -26,15 +26,14 @@ export function registerSetMissingTagCommand(program: TopLevelCommand) {
 
 async function setMissingTagsAction(
   options: TenantCommandOptions & GlobalCommandOptions,
-  foundationArg: string|undefined,
+  foundationArg: string | undefined,
   tagKey: string,
 ) {
-
   const repo = await CollieRepository.load();
   const logger = new Logger(repo, options);
-  
-  const foundation = foundationArg || 
-    CollieConfig.read_foundation(logger) ||
+
+  const foundation = foundationArg ||
+    CollieConfig.getFoundation(logger) ||
     (await InteractivePrompts.selectFoundation(repo, logger));
 
   const { meshAdapter } = await prepareTenantCommand(options, foundation);

--- a/src/commands/tenant/set-missing-tag.command.ts
+++ b/src/commands/tenant/set-missing-tag.command.ts
@@ -8,10 +8,9 @@ import { MeshInvalidTagValueError } from "../../errors.ts";
 import { TenantCommandOptions } from "./TenantCommandOptions.ts";
 import { prepareTenantCommand } from "./prepareTenantCommand.ts";
 import { TopLevelCommand } from "../TopLevelCommand.ts";
-import { CollieConfig } from "../../model/CollieConfig.ts";
-import { InteractivePrompts } from "../interactive/InteractivePrompts.ts";
 import { Logger } from "../../cli/Logger.ts";
 import { CollieRepository } from "../../model/CollieRepository.ts";
+import { getCurrentWorkingFoundation } from "../../cli/commandOptionsConventions.ts";
 
 export function registerSetMissingTagCommand(program: TopLevelCommand) {
   program
@@ -32,9 +31,11 @@ async function setMissingTagsAction(
   const repo = await CollieRepository.load();
   const logger = new Logger(repo, options);
 
-  const foundation = foundationArg ||
-    CollieConfig.getFoundation(logger) ||
-    (await InteractivePrompts.selectFoundation(repo, logger));
+  const foundation = await getCurrentWorkingFoundation(
+    foundationArg,
+    logger,
+    repo,
+  );
 
   const { meshAdapter } = await prepareTenantCommand(options, foundation);
 

--- a/src/commands/tenant/set-missing-tag.command.ts
+++ b/src/commands/tenant/set-missing-tag.command.ts
@@ -15,7 +15,7 @@ import { CollieRepository } from "../../model/CollieRepository.ts";
 
 export function registerSetMissingTagCommand(program: TopLevelCommand) {
   program
-    .command("set-missing-tag [foundation:foundation] <tagKey>")
+    .command("set-missing-tag <tagKey> [foundation:foundation]")
     .description("Fix all tenants missing the given tag interactively")
     .example(
       "Set a tag value for all tenants that are missing the given 'environment' tag",
@@ -26,8 +26,8 @@ export function registerSetMissingTagCommand(program: TopLevelCommand) {
 
 async function setMissingTagsAction(
   options: TenantCommandOptions & GlobalCommandOptions,
-  foundationArg: string | undefined,
   tagKey: string,
+  foundationArg: string | undefined,
 ) {
   const repo = await CollieRepository.load();
   const logger = new Logger(repo, options);

--- a/src/commands/tenant/tree.command.ts
+++ b/src/commands/tenant/tree.command.ts
@@ -18,15 +18,15 @@ export function registerTreeCommand(program: TenantCommand) {
 
 export async function treeTenantAction(
   options: GlobalCommandOptions,
-  foundationArg: string|undefined,
+  foundationArg: string | undefined,
 ) {
   const repo = await CollieRepository.load();
   const logger = new Logger(repo, options);
-  
-  const foundation = foundationArg || 
-    CollieConfig.read_foundation(logger) ||
+
+  const foundation = foundationArg ||
+    CollieConfig.getFoundation(logger) ||
     (await InteractivePrompts.selectFoundation(repo, logger));
-  
+
   const { meshAdapter } = await prepareTenantCommand(options, foundation);
 
   const allTenants = await meshAdapter.getMeshTenants();

--- a/src/commands/tenant/tree.command.ts
+++ b/src/commands/tenant/tree.command.ts
@@ -2,10 +2,9 @@ import { GlobalCommandOptions } from "../GlobalCommandOptions.ts";
 import { prepareTenantCommand } from "./prepareTenantCommand.ts";
 import { TreeTenantListPresenter } from "../../presentation/tree-tenant-list-presenter.ts";
 import { TenantCommand } from "./TenantCommand.ts";
-import { CollieConfig } from "../../model/CollieConfig.ts";
-import { InteractivePrompts } from "../interactive/InteractivePrompts.ts";
 import { Logger } from "../../cli/Logger.ts";
 import { CollieRepository } from "../../model/CollieRepository.ts";
+import { getCurrentWorkingFoundation } from "../../cli/commandOptionsConventions.ts";
 
 export function registerTreeCommand(program: TenantCommand) {
   program
@@ -23,9 +22,11 @@ export async function treeTenantAction(
   const repo = await CollieRepository.load();
   const logger = new Logger(repo, options);
 
-  const foundation = foundationArg ||
-    CollieConfig.getFoundation(logger) ||
-    (await InteractivePrompts.selectFoundation(repo, logger));
+  const foundation = await getCurrentWorkingFoundation(
+    foundationArg,
+    logger,
+    repo,
+  );
 
   const { meshAdapter } = await prepareTenantCommand(options, foundation);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,7 @@ import { FirstTimeExperience } from "./FirstTimeExperience.ts";
 import { CollieFoundationDoesNotExistError } from "./model/schemas/ModelValidator.ts";
 import { makeTopLevelCommand } from "./commands/TopLevelCommand.ts";
 import { registerInfoCommand } from "./commands/info.command.ts";
+import { registerConfigCommand } from "./commands/config/config.command.ts";
 
 async function collie() {
   const program = makeTopLevelCommand()
@@ -35,6 +36,8 @@ async function collie() {
   registerTenantCommand(program);
   registerKitCommand(program);
   registerComplianceCommand(program);
+
+  registerConfigCommand(program);
 
   registerInfoCommand(program);
   registerUpgradeCommand(program);

--- a/src/model/CollieConfig.ts
+++ b/src/model/CollieConfig.ts
@@ -2,16 +2,48 @@ import { Logger } from "../cli/Logger.ts";
 
 export class CollieConfig {
   static CONFIG_FILE_PATH = ".collie/config.json";
-  
-  static read_foundation(logger: Logger) {
+
+  static getFoundation(logger: Logger) {
     try {
-      const config = JSON.parse(Deno.readTextFileSync(this.CONFIG_FILE_PATH))
-      const foundation = config["foundation"]
-      logger.tip(`Foundation ${foundation} is set in ${this.CONFIG_FILE_PATH}`)
-      return foundation
+      const config = JSON.parse(Deno.readTextFileSync(this.CONFIG_FILE_PATH));
+      const foundation = config["foundation"];
+      logger.tip(`Foundation ${foundation} is set in ${this.CONFIG_FILE_PATH}`);
+      return foundation;
     } catch (e) {
-      if (e.name != "NotFound")
-        console.log(e)
+      if (e.name != "NotFound") {
+        console.log(e);
+      }
     }
+  }
+
+  /**
+   * This function sets the foundation property in CollieConfig.
+   * It does not preserve the order of the keys.
+   * @param foundation
+   * @param logger
+   */
+  static async setFoundation(
+    foundation: string,
+    logger: Logger,
+  ) {
+    let config;
+    try {
+      config = JSON.parse(await Deno.readTextFile(this.CONFIG_FILE_PATH));
+      config["foundation"] = foundation;
+    } catch (error) {
+      if (error.name != "NotFound") {
+        console.error(error);
+      }
+
+      config = { "foundation": foundation };
+    }
+
+    Deno.writeTextFile(
+      CollieConfig.CONFIG_FILE_PATH,
+      JSON.stringify(config),
+    );
+    logger.progress(
+      `set current foundation to ${foundation} in ${CollieConfig.CONFIG_FILE_PATH}`,
+    );
   }
 }

--- a/src/model/CollieConfig.ts
+++ b/src/model/CollieConfig.ts
@@ -1,0 +1,17 @@
+import { Logger } from "../cli/Logger.ts";
+
+export class CollieConfig {
+  static CONFIG_FILE_PATH = ".collie/config.json";
+  
+  static read_foundation(logger: Logger) {
+    try {
+      const config = JSON.parse(Deno.readTextFileSync(this.CONFIG_FILE_PATH))
+      const foundation = config["foundation"]
+      logger.tip(`Foundation ${foundation} is set in ${this.CONFIG_FILE_PATH}`)
+      return foundation
+    } catch (e) {
+      if (e.name != "NotFound")
+        console.log(e)
+    }
+  }
+}

--- a/src/model/CollieConfig.ts
+++ b/src/model/CollieConfig.ts
@@ -6,7 +6,7 @@ export class CollieConfig {
   static getFoundation(logger: Logger) {
     try {
       const config = JSON.parse(Deno.readTextFileSync(this.CONFIG_FILE_PATH));
-      const foundation = config["foundation"];
+      const foundation = config["foundation"] as string;
       logger.tip(`Foundation ${foundation} is set in ${this.CONFIG_FILE_PATH}`);
       return foundation;
     } catch (e) {

--- a/src/model/CollieRepository.ts
+++ b/src/model/CollieRepository.ts
@@ -48,7 +48,7 @@ export class CollieRepository {
 
       if (!components.length) {
         throw new Error(
-          `${absolutePath} nor any of its parent directories seemse to be a collie repository`,
+          `${absolutePath} nor any of its parent directories seems to be a collie repository`,
         );
       }
     }


### PR DESCRIPTION
Introduce `collie config` and `collie config set-foundation`.

```
❯ collie config                                                                                                                                                                                                         

  Usage:   collie config
  Version: DEVELOPMENT

  Description:

    View and edit collie repository config.

  Options:

    -h, --help  - Show this help.
    --verbose   - Enable printing verbose info (command execution and results)
    --debug     - Enable printing debug info (command output, intermediate results)

  Commands:

    set-foundation  [foundation]  - Set the foundation config property.
    get             <property>    - Get a config property from the repository config.
```

I adapted the tutorials on collie-hub https://github.com/meshcloud/collie-hub/pull/37