### PR TITLE
Feature/collie run in subfolder

### DIFF
--- a/src/commands/compliance/new.command.ts
+++ b/src/commands/compliance/new.command.ts
@@ -14,7 +14,7 @@ export function registerNewCmd(program: TopLevelCommand) {
     .description("generate a new compliance control")
     .action(
       async (opts: GlobalCommandOptions, module: string, name?: string) => {
-        const kit = new CollieRepository("./");
+        const kit = await CollieRepository.load();
         const logger = new Logger(kit, opts);
 
         const controlPath = kit.resolvePath("compliance", module + ".md");

--- a/src/commands/compliance/tree.command.ts
+++ b/src/commands/compliance/tree.command.ts
@@ -22,7 +22,7 @@ export function registerTreeCmd(program: TopLevelCommand) {
     .command("tree")
     .description("show the compliance control tree with module implementations")
     .action(async (opts: GlobalCommandOptions) => {
-      const repo = new CollieRepository("./");
+      const repo = await CollieRepository.load();
       const logger = new Logger(repo, opts);
 
       const results = await prepareAnalyzeCommand(repo, logger);

--- a/src/commands/foundation/tree.command.ts
+++ b/src/commands/foundation/tree.command.ts
@@ -18,7 +18,7 @@ export function registerTreeCmd(program: TopLevelCommand) {
     .command("tree")
     .description("show the foundation tree with module dependencies")
     .action(async (opts: GlobalCommandOptions) => {
-      const collie = new CollieRepository("./");
+      const collie = await CollieRepository.load();
       const logger = new Logger(collie, opts);
 
       const analyzeResults = await prepareAnalyzeCommand(collie, logger);

--- a/src/commands/info.command.ts
+++ b/src/commands/info.command.ts
@@ -18,7 +18,7 @@ export function registerInfoCommand(program: TopLevelCommand) {
       console.log(`Runtime:`);
       console.log(`deno ${Deno.version.deno} ${Deno.build.target}\n`);
 
-      const collie = new CollieRepository("./");
+      const collie = await CollieRepository.load();
       const logger = new Logger(collie, opts);
 
       const factory = new CliApiFacadeFactory(collie, logger);

--- a/src/commands/kit/apply.command.ts
+++ b/src/commands/kit/apply.command.ts
@@ -100,7 +100,7 @@ export async function applyKitModule(
   moduleId: string,
 ) {
   const dir = new DirectoryGenerator(WriteMode.skip, logger);
-  const collie = new CollieRepository("./");
+  const collie = await CollieRepository.load();
   const platformConfig = foundationRepo.findPlatform(platform);
 
   const platformModuleId = moduleId.split("/").slice(1);

--- a/src/commands/kit/bundle.command.ts
+++ b/src/commands/kit/bundle.command.ts
@@ -56,7 +56,7 @@ export function registerBundledKitCmd(program: TopLevelCommand) {
     )
     .action(
       async (opts: GlobalCommandOptions & BundleOptions, prefix: string) => {
-        const collie = new CollieRepository("./");
+        const collie = await CollieRepository.load();
         const logger = new Logger(collie, opts);
         const validator = new ModelValidator(logger);
 

--- a/src/commands/kit/compile.command.ts
+++ b/src/commands/kit/compile.command.ts
@@ -12,7 +12,7 @@ export function registerCompileCmd(program: TopLevelCommand) {
     .command("compile [module]")
     .description("Compile kit modules, updating their documentation")
     .action(async (opts: GlobalCommandOptions, module?: string) => {
-      const collie = new CollieRepository("./");
+      const collie = await CollieRepository.load();
       const logger = new Logger(collie, opts);
       const validator = new ModelValidator(logger);
       const moduleRepo = await KitModuleRepository.load(

--- a/src/commands/kit/import.command.ts
+++ b/src/commands/kit/import.command.ts
@@ -28,7 +28,7 @@ export function registerImportCmd(program: TopLevelCommand) {
       "Import a published kit module from the official Collie Hub at https://github.com/meshcloud/collie-hub",
     )
     .action(async (opts: GlobalCommandOptions & ImportOptions, id?: string) => {
-      const collie = new CollieRepository("./");
+      const collie = await CollieRepository.load();
       const logger = new Logger(collie, opts);
 
       const factory = new CliApiFacadeFactory(collie, logger);

--- a/src/commands/kit/new.command.ts
+++ b/src/commands/kit/new.command.ts
@@ -11,7 +11,7 @@ export function registerNewCmd(program: TopLevelCommand) {
     .description("Generate a new kit module terraform template")
     .action(
       async (opts: GlobalCommandOptions, module: string, name?: string) => {
-        const collie = new CollieRepository("./");
+        const collie = await CollieRepository.load();
         const logger = new Logger(collie, opts);
 
         const modulePath = collie.resolvePath("kit", module);

--- a/src/commands/kit/tree.command.ts
+++ b/src/commands/kit/tree.command.ts
@@ -15,7 +15,7 @@ export function registerTreeCmd(program: TopLevelCommand) {
     .command("tree")
     .description("Show kit modules their dependent platform modules")
     .action(async (opts: GlobalCommandOptions) => {
-      const collie = new CollieRepository("./");
+      const collie = await CollieRepository.load();
       const logger = new Logger(collie, opts);
 
       const analyzeResults = await prepareAnalyzeCommand(collie, logger);

--- a/src/foundation/FoundationDependenciesTreeBuilder.ts
+++ b/src/foundation/FoundationDependenciesTreeBuilder.ts
@@ -59,16 +59,20 @@ export class FoundationDependenciesTreeBuilder {
   private buildModuleTree(platform: PlatformDependencies): PlatformTree {
     const tree: PlatformTree = {};
 
-    const platformPath = this.foundation.resolvePlatformPath(platform.platform);
+    const resolvedPlatformPath = this.foundation.resolvePlatformPath(
+      platform.platform,
+    );
 
     platform.modules.forEach((m) => {
-      const moduleDir = path.relative(
-        platformPath,
-        path.resolve(m.sourcePath, "../"),
+      const resolvedPlatformModulePath = this.collie.resolvePath(
+        path.dirname(m.sourcePath),
       );
 
-      const label = this.collie.relativePath(m.sourcePath);
-      const labeledComponents = buildLabeledIdPath(moduleDir, label);
+      const relativePath = resolvedPlatformModulePath.substring(
+        resolvedPlatformPath.length + "/".length,
+      );
+      const label = m.sourcePath;
+      const labeledComponents = buildLabeledIdPath(relativePath, label);
 
       insert<ModuleNode>(tree, labeledComponents, {
         kitModule: colors.green(m.kitModuleId),

--- a/src/kit/KitDependencyAnalyzer.ts
+++ b/src/kit/KitDependencyAnalyzer.ts
@@ -105,7 +105,9 @@ export class KitDependencyAnalyzer {
     }
 
     const kitModuleId = kitModuleSource.replace("${get_repo_root()}//kit/", "");
-    const kitModulePath = this.kitModules.resolvePath(kitModuleId);
+    const kitModulePath = this.collie.relativePath(
+      this.kitModules.resolvePath(kitModuleId),
+    );
     const kitModule = this.kitModules.tryFindById(kitModuleId);
 
     if (!kitModule) {

--- a/src/model/CollieRepository.ts
+++ b/src/model/CollieRepository.ts
@@ -39,20 +39,21 @@ export class CollieRepository {
   }
 
   static async load(searchDir = "./"): Promise<CollieRepository> {
-    const absolutePath = path.resolve(searchDir);
-    const components = absolutePath.split(path.SEP);
+    let absolutePath = path.resolve(searchDir);
+    console.log(path.dirname(absolutePath));
 
     // find parent directory containing the next best git repository
-    while (!(await fs.exists(path.join(...components, ".git")))) {
-      components.pop();
+    while (!(await fs.exists(path.join(absolutePath, ".git")))) {
+      console.log(path.dirname(absolutePath));
+      absolutePath = path.dirname(absolutePath);
 
-      if (!components.length) {
+      if (absolutePath == path.dirname(absolutePath)) {
         throw new Error(
           `${absolutePath} nor any of its parent directories seems to be a collie repository`,
         );
       }
     }
 
-    return new CollieRepository(path.join(...components));
+    return new CollieRepository(absolutePath);
   }
 }

--- a/src/model/CollieRepository.ts
+++ b/src/model/CollieRepository.ts
@@ -45,7 +45,8 @@ export class CollieRepository {
     while (!(await fs.exists(path.join(absolutePath, ".git")))) {
       absolutePath = path.dirname(absolutePath);
 
-      if (absolutePath == path.dirname(absolutePath)) {
+      const isAtRootOfFilesystem = absolutePath == path.dirname(absolutePath);
+      if (isAtRootOfFilesystem) {
         throw new Error(
           `${absolutePath} nor any of its parent directories seems to be a collie repository`,
         );

--- a/src/model/CollieRepository.ts
+++ b/src/model/CollieRepository.ts
@@ -40,11 +40,9 @@ export class CollieRepository {
 
   static async load(searchDir = "./"): Promise<CollieRepository> {
     let absolutePath = path.resolve(searchDir);
-    console.log(path.dirname(absolutePath));
 
     // find parent directory containing the next best git repository
     while (!(await fs.exists(path.join(absolutePath, ".git")))) {
-      console.log(path.dirname(absolutePath));
       absolutePath = path.dirname(absolutePath);
 
       if (absolutePath == path.dirname(absolutePath)) {


### PR DESCRIPTION
Fix running in subfolders.

The problem under mac OS was due to a missing `/` at the beginning of the absolute path. However, adding `path.SEP` there would not work for windows, so we now use `path.dirname` 