### PR TITLE
fix: Powershell upgrade scenario not workign

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -46,7 +46,7 @@ $Path = [Environment]::GetEnvironmentVariable('Path', $User)
 if (!(";$Path;".ToLower() -like "*;$BinDir;*".ToLower())) {
  
     # Ask user whether to add Collie to PATH
-    $userenv = $(Write-Host "Do you want to add Collie CLI to PATH? (y/n)" -NoNewLine -ForegroundColor Green; Read-Host)
+    $userenv = $(Write-Host "Could not find collie CLI on PATH. Do you want to add collie CLI to PATH? (y/n)" -NoNewLine -ForegroundColor Green; Read-Host)
     if ($userenv -like "y") {
         Write-Host "Adding $BinDir to PATH" -ForegroundColor Green
         [Environment]::SetEnvironmentVariable('Path', "$Path;$BinDir", $User)

--- a/install.ps1
+++ b/install.ps1
@@ -1,8 +1,8 @@
 Clear-Host
 Write-Host "`nStarting Installation of Collie ..." -ForegroundColor Green
-
+ 
 $ProgressPreference = "SilentlyContinue" # Don't remove this! Otherwise it will slow down the Download-Process under PS 5
-
+ 
 # Check the latest release to get the exact download URL
 try {
     $query = Invoke-RestMethod -Uri "https://api.github.com/repos/meshcloud/collie-cli/releases/latest"
@@ -11,45 +11,48 @@ try {
 catch {
     throw "[ERROR] while downloading installation file. Check your Internet Connection: $(_.Exception.Message)!"
 }
-
-$installationPath = "${HOME}\collie-cli\$($query.name)"
-Write-Host $($installationPath)
-
+ 
+$installationPath = "${HOME}\collie-cli"
+$installationExec = "$installationPath\collie.exe"
+Write-Host "Scanning '$($installationPath)' for existing installations"
+ 
 # Determine whether this is a fresh install or if Collie has yet been installed before
-if ( !(Test-Path -Path $installationPath) ) {
-    $folder = New-Item -ItemType directory -Path "${HOME}\collie-cli\$($query.name)"
+if ( !(Test-Path -Path $installationExec) ) {
+    $folder = New-Item -ItemType directory -Path $installationPath
     if ($?) { Write-Host "[OK] Application-Folder '$installationPath' created!" -ForegroundColor Green }
 }
-elseif ( Test-Path -Path $($installationPath + "\collie.exe") ) {
-    $replace = $(Write-Host "Replace existing Installation (y/n)? " -NoNewLine -ForegroundColor Green; Read-Host) 
+elseif ( Test-Path -Path $installationExec) {
+    $replace = $(Write-Host "Collie already exists. Do you want to replace the existing Installation (y/n)? " -NoNewLine -ForegroundColor Green; Read-Host) 
     if ($replace -like "y") {
-        Remove-Item -Path $installationPath -Recurse -Force
-        $folder = New-Item -ItemType directory -Path "${HOME}\collie-cli\$($query.name)"
+        Remove-Item $installationExec -Force
     }
     else { Exit } 
 }
-
+ 
 # Download Collie and save it as an .exe
 try {
     Write-Host "Downloading Collie Version '$($query.Name)' ..." -ForegroundColor Green
-    $download = Invoke-WebRequest -Uri $downloadUrl.browser_download_url -OutFile "$($folder.FullName)\collie.exe" -PassThru
+    $download = Invoke-WebRequest -Uri $downloadUrl.browser_download_url -OutFile $installationExec -PassThru
     if ($?) { Write-Host "[OK] Download-Size '$([math]::Round($download.RawContentLength/1MB)),2 MB'`n" -ForegroundColor Green }
 }
 catch {
     throw "[ERROR] while downloading Installation File: $($($_.Exception).Message)!"
 }
-
-# Ask user whether to add Collie to the environment variables automatically
-$userenv = $(Write-Host "Adding Collie to your Environment-Variables? (y/n)" -NoNewLine -ForegroundColor Green; Read-Host)
-if ($userenv -like "y") {
-    $BinDir = $($folder.FullName).ToString()
-    $User = [EnvironmentVariableTarget]::User
-    $Path = [Environment]::GetEnvironmentVariable('Path', $User)
-    if (!(";$Path;".ToLower() -like "*;$BinDir;*".ToLower())) {
+ 
+# Check if Collie is already in PATH
+$BinDir = $installationPath
+$User = [EnvironmentVariableTarget]::User
+$Path = [Environment]::GetEnvironmentVariable('Path', $User)
+if (!(";$Path;".ToLower() -like "*;$BinDir;*".ToLower())) {
+ 
+    # Ask user whether to add Collie to PATH
+    $userenv = $(Write-Host "Do you want to add Collie CLI to PATH? (y/n)" -NoNewLine -ForegroundColor Green; Read-Host)
+    if ($userenv -like "y") {
+        Write-Host "Adding $BinDir to PATH" -ForegroundColor Green
         [Environment]::SetEnvironmentVariable('Path', "$Path;$BinDir", $User)
         $Env:Path += ";$BinDir"
     }
 }
-
-Write-Host "[OK] Collie CLI successfully installed: '$($folder.FullName)'`n" -ForegroundColor Green
+ 
+Write-Host "[OK] Collie CLI successfully installed at $installationExec" -ForegroundColor Green
 Write-Output "Run 'collie --help' to get started"


### PR DESCRIPTION
When Collie was already installed on the machine, the install script did not clean up the old version. This scenario only worked when the installed version matches the latest version on GitHub. For example I had 0.7.0 installed but it didn't find that directory and clean it up from the file system and PATH.

I instead changed the installation to be version independent so we don't have to magically check for all possible installed versions but we just replace whatever Collie executable is there.