### PR TITLE
feat: add a "compliance import" format

### DIFF
--- a/src/commands/compliance/compliance.command.ts
+++ b/src/commands/compliance/compliance.command.ts
@@ -1,4 +1,5 @@
 import { makeTopLevelCommand, TopLevelCommand } from "../TopLevelCommand.ts";
+import { registerImportCmd } from "./import.command.ts";
 import { registerNewCmd } from "./new.command.ts";
 import { registerTreeCmd } from "./tree.command.ts";
 
@@ -7,6 +8,7 @@ export function registerComplianceCommand(program: TopLevelCommand) {
 
   registerTreeCmd(complianceCommands);
   registerNewCmd(complianceCommands);
+  registerImportCmd(complianceCommands);
 
   program
     .command("compliance", complianceCommands)

--- a/src/commands/compliance/import.command.ts
+++ b/src/commands/compliance/import.command.ts
@@ -1,0 +1,94 @@
+import { Select } from "x/cliffy/prompt";
+import { Logger } from "../../cli/Logger.ts";
+import { CollieRepository } from "../../model/CollieRepository.ts";
+import { GlobalCommandOptions } from "../GlobalCommandOptions.ts";
+import { TopLevelCommand } from "../TopLevelCommand.ts";
+import { CliApiFacadeFactory } from "../../api/CliApiFacadeFactory.ts";
+import { CollieHub } from "../../model/CollieHub.ts";
+
+interface ImportOptions {
+  clean?: boolean;
+  force?: boolean;
+}
+
+export function registerImportCmd(program: TopLevelCommand) {
+  program
+    .command("import [id]")
+    .option(
+      "--force",
+      "overwrite existing compliance control files in the local collie repository",
+    )
+    .option(
+      "--clean",
+      "clean the local cache of the collie hub before importing instead of just refreshing it",
+    )
+    .description(
+      "Import a published compliance control framework from the official Collie Hub at https://github.com/meshcloud/collie-hub",
+    )
+    .action(async (opts: GlobalCommandOptions & ImportOptions, id?: string) => {
+      const collie = await CollieRepository.load();
+      const logger = new Logger(collie, opts);
+
+      const factory = new CliApiFacadeFactory(collie, logger);
+      const git = factory.buildGit();
+
+      const hub = new CollieHub(git, collie);
+
+      if (opts.clean) {
+        logger.progress("cleaning local cache of collie hub");
+        await hub.cleanHubClone();
+      }
+
+      logger.progress("updating local cache of collie hub from " + hub.url);
+      const hubDir = await hub.updateHubClone();
+
+      id = id || (await promptForComplianceFrameworkId(logger, hubDir));
+
+      const dstPath = collie.resolvePath("compliance", id);
+      try {
+        await hub.importComplianceFramework(id, dstPath, opts.force);
+      } catch (e) {
+        if (e instanceof Deno.errors.AlreadyExists) {
+          logger.error(
+            (fmt) =>
+              "Error: A local compliance control framework already exists at " +
+              fmt.kitPath(dstPath),
+          );
+
+          logger.tip("add --force to overwrite existing files");
+
+          Deno.exit(1);
+        }
+
+        throw e;
+      }
+
+      logger.progress(
+        "imported compliance control framework at " +
+          collie.relativePath(
+            collie.resolvePath("compliance", id, "README.md"),
+          ),
+      );
+    });
+}
+
+async function promptForComplianceFrameworkId(
+  logger: Logger,
+  hubRepoDir: string,
+) {
+  // note: the hub is a standard collie repository for the most part, so we can just parse it with the same code
+  const repo = await CollieRepository.load(hubRepoDir);
+  const complianceDir = repo.resolvePath("compliance");
+
+  const dirs = [];
+  for await (const dirEntry of Deno.readDir(complianceDir)) {
+    if (dirEntry.isDirectory) {
+      dirs.push(dirEntry.name);
+    }
+  }
+
+  return await Select.prompt({
+    message: "Select available collie hub compliance control framework",
+    options: dirs.map((x) => ({ name: x, value: x })),
+  });
+}

--- a/src/commands/kit/import.command.ts
+++ b/src/commands/kit/import.command.ts
@@ -6,7 +6,7 @@ import { CliApiFacadeFactory } from "../../api/CliApiFacadeFactory.ts";
 import { KitModuleRepository } from "../../kit/KitModuleRepository.ts";
 import { ModelValidator } from "../../model/schemas/ModelValidator.ts";
 import { InteractivePrompts } from "../interactive/InteractivePrompts.ts";
-import { KitModuleHub } from "./KitModuleHub.ts";
+import { CollieHub } from "../../model/CollieHub.ts";
 
 interface ImportOptions {
   clean?: boolean;
@@ -34,7 +34,7 @@ export function registerImportCmd(program: TopLevelCommand) {
       const factory = new CliApiFacadeFactory(collie, logger);
       const git = factory.buildGit();
 
-      const hub = new KitModuleHub(git, collie);
+      const hub = new CollieHub(git, collie);
 
       if (opts.clean) {
         logger.progress("cleaning local cache of hub modules");
@@ -48,7 +48,7 @@ export function registerImportCmd(program: TopLevelCommand) {
 
       const dstPath = collie.resolvePath("kit", id);
       try {
-        await hub.import(id, dstPath, opts.force);
+        await hub.importKitModule(id, dstPath, opts.force);
       } catch (e) {
         if (e instanceof Deno.errors.AlreadyExists) {
           logger.error(
@@ -86,6 +86,6 @@ async function promptForKitModuleId(logger: Logger, hubRepoDir: string) {
 
   return await InteractivePrompts.selectModule(
     moduleRepo,
-    "official hub modules",
+    "official collie hub modules",
   );
 }

--- a/src/model/CollieHub.ts
+++ b/src/model/CollieHub.ts
@@ -1,8 +1,8 @@
 import * as fs from "std/fs";
-import { GitCliFacade } from "../../api/git/GitCliFacade.ts";
-import { CollieRepository } from "../../model/CollieRepository.ts";
+import { GitCliFacade } from "/api/git/GitCliFacade.ts";
+import { CollieRepository } from "/model/CollieRepository.ts";
 
-export class KitModuleHub {
+export class CollieHub {
   constructor(
     private readonly git: GitCliFacade,
     private readonly repo: CollieRepository,
@@ -12,14 +12,32 @@ export class KitModuleHub {
   // hardcoding this is ok for now
   readonly url = "https://github.com/meshcloud/collie-hub.git";
 
-  public async import(id: string, moduleDestDir: string, overwrite?: boolean) {
-    const moduleSrcDir = this.repo.resolvePath(
+  public async importKitModule(
+    id: string,
+    moduleDestDir: string,
+    overwrite?: boolean,
+  ) {
+    const srcDir = this.repo.resolvePath(
       ...this.hubCacheDirPath,
       "kit",
       id,
     );
 
-    await fs.copy(moduleSrcDir, moduleDestDir, { overwrite: overwrite });
+    await fs.copy(srcDir, moduleDestDir, { overwrite: overwrite });
+  }
+
+  public async importComplianceFramework(
+    id: string,
+    frameworkDestDir: string,
+    overwrite?: boolean,
+  ) {
+    const srcDir = this.repo.resolvePath(
+      ...this.hubCacheDirPath,
+      "compliance",
+      id,
+    );
+
+    await fs.copy(srcDir, frameworkDestDir, { overwrite: overwrite });
   }
 
   async updateHubClone() {


### PR DESCRIPTION
this re-uses the same structure we already have for collie hub to update and import compliance controls

I'm not sure how valuable the concept of compliance frameworks proves to be in the long run but adding this an experimental command made sense especially since the implementation was so easy based on what we already had for `kit import`