### PR TITLE
Feature/compliance tree

### DIFF
--- a/src/commands/compliance/tree.command.ts
+++ b/src/commands/compliance/tree.command.ts
@@ -50,12 +50,11 @@ export function registerTreeCmd(program: TopLevelCommand) {
       );
 
       if (!hasAnyApplicableStatements) {
-        logger.warn("no compliance control statement found in a kit module");
+        logger.warn("no compliance control statements found in an< kit module");
         logger.tip(
           `Add a compliance section to your kit module frontmatter like this\n` +
             statementExample,
         );
-        return;
       }
 
       await renderControlTree(repo, results, controls);
@@ -69,7 +68,11 @@ function renderControlTree(
 ) {
   const { dependencies } = results;
 
-  const builder = new ComplianceControlTreeBuilder(collie, controls);
+  const builder = new ComplianceControlTreeBuilder(
+    collie,
+    results.modules,
+    controls,
+  );
 
   const tree = builder.build(dependencies.map((x) => x.results));
 

--- a/src/commands/kit/tree.command.ts
+++ b/src/commands/kit/tree.command.ts
@@ -36,7 +36,6 @@ export function registerTreeCmd(program: TopLevelCommand) {
       if (!hasAppliedModules) {
         logger.warn("no kit modules applied to any platform");
         logger.tipCommand(`To apply a kit module run`, `kit apply "my-module"`);
-        return;
       }
 
       renderKitTree(collie, analyzeResults);


### PR DESCRIPTION
These changes are useful to work with collie cli on the collie hub repo, which doesn't have foundations and hence no platform modules.

For "compliance tree" this PR also fixes a bug where it would only show compliance statements for applied modules