### PR TITLE
Feature/ask for foundation name

### DIFF
--- a/src/commands/foundation/new.command.ts
+++ b/src/commands/foundation/new.command.ts
@@ -1,5 +1,5 @@
 import * as colors from "std/fmt/colors";
-import { prompt, Select } from "x/cliffy/prompt";
+import { Input, prompt, Select } from "x/cliffy/prompt";
 import { Logger } from "../../cli/Logger.ts";
 import {
   Dir,
@@ -21,9 +21,13 @@ import { CollieConfig } from "../../model/CollieConfig.ts";
 
 export function registerNewCmd(program: TopLevelCommand) {
   program
-    .command("new <foundation:foundation>")
+    .command("new [foundation:foundation]")
     .description("generate a new cloud foundation")
-    .action(async (opts: GlobalCommandOptions, foundation: string) => {
+    .action(async (opts: GlobalCommandOptions, foundationArg: string) => {
+      const foundation: string = foundationArg ||
+        await Input.prompt(
+          `Choose a name for your new foundation`,
+        );
       const repo = await CollieRepository.load();
       const logger = new Logger(repo, opts);
 

--- a/src/model/CollieConfig.ts
+++ b/src/model/CollieConfig.ts
@@ -1,3 +1,5 @@
+import * as path from "std/path";
+import * as fs from "std/fs";
 import { Logger } from "../cli/Logger.ts";
 import { CollieRepository } from "./CollieRepository.ts";
 
@@ -58,6 +60,8 @@ export class CollieConfig {
   }
 
   private async saveToDisk() {
+    await fs.ensureDir(path.dirname(this.configFilePath));
+
     await Deno.writeTextFile(
       this.configFilePath,
       JSON.stringify(this.properties),


### PR DESCRIPTION
- asking for foundation name via `Input` feels more consistent with how the rest of collie commands treat parameters
- fixes crashes due to missing .collie dir