### PR TITLE
feat: configure collie repo with LF line endings

### DIFF
--- a/src/commands/init.command.ts
+++ b/src/commands/init.command.ts
@@ -39,6 +39,7 @@ export function registerInitCommand(program: TopLevelCommand) {
           entries: [
             { name: "README.md", content: readmeMd },
             { name: ".gitignore", content: gitignore },
+            { name: ".gitattributes", content: gitattributes },
             {
               name: "kit",
               entries: [
@@ -138,6 +139,14 @@ const gitignore = `# terraform/terragrunt caches
 # collie cache
 **.collie.json
 **.meta.json
+`;
+
+const gitattributes = `# Force LF file endings for all text files
+* text eol=lf
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary
 `;
 
 const kitReadmeMd = `# Your Collie Kit


### PR DESCRIPTION
collie cli's code generation emits LF endings and a lot of the parsing code e.g. for yaml frontmatter expects this as well

also, we're switching collie hub to LF endings as well https://github.com/meshcloud/collie-hub/pull/63