### PR TITLE
fix: when exiting collie via SIGTERM or SIGINT wait for subprocesses

### DIFF
--- a/src/process/TransparentProcessRunner.ts
+++ b/src/process/TransparentProcessRunner.ts
@@ -27,6 +27,12 @@ export class TransparentProcessRunner implements IProcessRunner<ProcessResult> {
     });
 
     const p = cmd.spawn();
+
+    // make sure Deno exits only after the process has exited as well.
+    // this is important for correct signal handling beahvior (e.g. SIGTERM cia Ctrl+C) so that collie waits for
+    // its subprocess to finish (and rendering all its output) before exiting itself
+    p.ref();
+
     const status = await p.status;
 
     const result: ProcessResult = {


### PR DESCRIPTION
this fixes a bug where collie would exit first and yield back to the shell and subprocesses like terragrunt would continue writing their output to