### PR TITLE
Remove module.hcl from fallback templates generated by "kit apply"

### DIFF
--- a/src/commands/kit/kit-utilities.ts
+++ b/src/commands/kit/kit-utilities.ts
@@ -103,8 +103,16 @@ export async function generateTerragrunt(
   path = find_in_parent_folders("platform.hcl")
 }`;
 
-  const moduleIncludeBlock = `include "module" {
-  path = find_in_parent_folders("module.hcl")
+  const providerBlock =
+    `# todo: setup providers as needed by your kit module, typically referencing outputs of the bootstrap module
+# note: this block is generated as a fallback, since the kit module provided no explicit terragrunt.hcl template
+generate "provider" {
+  path      = "provider.tf"
+  if_exists = "overwrite"
+  contents  = <<EOF
+provider "google|aws|azurerm" {
+}
+EOF
 }`;
 
   const bootstrapProviderBlock =
@@ -132,7 +140,7 @@ ${indent(tfvars, 2)}
 
   return [
     platformIncludeBlock,
-    isBootstrap ? bootstrapProviderBlock : moduleIncludeBlock,
+    isBootstrap ? bootstrapProviderBlock : providerBlock,
     terraformBlock,
     inputsBlock,
   ].join("\n\n");

--- a/src/commands/kit/kit-utilities.ts
+++ b/src/commands/kit/kit-utilities.ts
@@ -110,8 +110,7 @@ generate "provider" {
   path      = "provider.tf"
   if_exists = "overwrite"
   contents  = <<EOF
-provider "google|aws|azurerm" {
-}
+# todo: add provider {} blocks as needed
 EOF
 }`;
 


### PR DESCRIPTION
We have stopped including separate module.hcl in bootstrap modules on collie hub
While the idea of DRY'ing provider configuration across multiple modules is good in theory,
it adds another layer of learning curve and also gets in the way for more complex kit modules that need to 
work with multiple provider instances (e.g. on multiple AWS Accounts etc.)