### PR TITLE
feat: pass --preview and --build as simple flags to foundation docs

### DIFF
--- a/src/commands/foundation/docs.command.ts
+++ b/src/commands/foundation/docs.command.ts
@@ -77,18 +77,14 @@ export function registerDocsCmd(program: TopLevelCommand) {
       },
     )
     .option(
-      "--preview [preview:boolean]",
+      "--preview",
       "Render documentation to HTML using static site generator and start local web-server preview.",
-      {
-        default: false,
-      },
+      { conflicts: ["build"] },
     )
     .option(
-      "--build [build:boolean]",
+      "--build",
       "Render documentation to HTML using static site generator.",
-      {
-        default: false,
-      },
+      { conflicts: ["preview"] },
     );
 }
 


### PR DESCRIPTION
This makes collie behave consistently on windows and linux. Before we could do "foundation docs --build" on linux but on windows we needed "foundation docs --build true".