### PR TITLE
Fix: improve collie repository file scanning robustness

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   build:
-    if: ${{ success() }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -40,3 +39,24 @@ jobs:
       - name: cheap integration test
         run: |
           deno task run
+  # run tests on windows because that allows us testing path.SEP related issues in integraiton tests
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: denoland/setup-deno@main
+        with:
+          deno-version: "~1.37"
+      - uses: actions/cache@v3
+        with:
+          path: ~/.cache/deno        # see https://deno.land/manual/linking_to_external_code
+          key: ${{ runner.os }}-deno # it seems there's no particular cache keying required
+          restore-keys: |
+            ${{ runner.os }}-deno
+      - name: deno info
+        run: |
+          deno --version
+          deno info
+      - name: test
+        run: |
+          deno task test

--- a/src/api/terragrunt/TerragruntCliFacade.ts
+++ b/src/api/terragrunt/TerragruntCliFacade.ts
@@ -61,11 +61,16 @@ export class TerragruntCliFacade {
     opts: TerragruntRunAllOpts,
   ) {
     // note: terragrunt docs say "This will only exclude the module, not its dependencies."
-    // this may be a problem because we want to exclude bootstrap modules AND their dependencies? needs more testing
-    const excludeDirFlags = (opts.excludeDirs || []).flatMap((x) => [
-      "--terragrunt-exclude-dir",
-      x,
-    ]);
+    // this is fine considering that if we e.g. bootstrap module (usual case), this is just a single module without
+    // further dependencies
+
+    // see https://github.com/gruntwork-io/terragrunt/issues/2737
+    const workaroundTerragruntOnWindowsScanningItsOwnCaches =
+      "**/.terragrunt-cache/**/*";
+
+    const excludeDirFlags = (opts.excludeDirs || [])
+      .concat([workaroundTerragruntOnWindowsScanningItsOwnCaches])
+      .flatMap((x) => ["--terragrunt-exclude-dir", x]);
 
     // By default, "terragrunt run-all" auto approves all individual applies, a notable difference to "terragrunt run"
     // which does interactive confirmation prompts by default.

--- a/src/cli/DirectoryGenerator.test.ts
+++ b/src/cli/DirectoryGenerator.test.ts
@@ -86,8 +86,8 @@ Deno.test(
 Deno.test(
   "can write into relative dir",
   async () =>
-    await withRestoreCwd(async () => {
-      await withTempDir(async (tmp) => {
+    await withTempDir(async (tmp) => {
+      await withRestoreCwd(async () => {
         Deno.chdir(tmp);
 
         const sut = new DirectoryGenerator(WriteMode.overwrite, nullLogger);

--- a/src/commands/PlatformType.ts
+++ b/src/commands/PlatformType.ts
@@ -2,19 +2,15 @@ import * as fs from "std/fs";
 import * as path from "std/path";
 
 import { StringType } from "x/cliffy/command";
+import { CollieRepository } from "../model/CollieRepository.ts";
 
 export class PlatformType extends StringType {
   async complete(): Promise<string[]> {
-    const platforms = [];
-
-    for await (
-      const file of fs.expandGlob(
-        "foundations/*/platforms/*/README.md",
-      )
-    ) {
-      const id = path.basename(path.dirname(file.path));
-      platforms.push(id);
-    }
+    const repo = await CollieRepository.load();
+    const platforms = await repo.processFilesGlob(
+      "foundations/*/platforms/*/README.md",
+      (file) => path.basename(path.dirname(file.path)),
+    );
 
     // I don't know how we could get the foundation name passed to the arg to filter
     // only to the platforms in the already specified foundation

--- a/src/commands/foundation/PlatformModuleType.test.ts
+++ b/src/commands/foundation/PlatformModuleType.test.ts
@@ -1,16 +1,36 @@
 import { assertEquals } from "std/testing/assert";
 import { PlatformModuleType } from "./PlatformModuleType.ts";
+import * as path from "std/path";
 
 Deno.test("parseModuleId parses simple ids", () => {
-  const path = "/Users/foundations/f/platforms/p/foo/terragrunt.hcl";
-  const result = PlatformModuleType.parseModuleId(path);
+  const modulePath = path.join(
+    "Users",
+    "foundations",
+    "f",
+    "platforms",
+    "p",
+    "foo",
+    "terragrunt.hcl",
+  );
+
+  const result = PlatformModuleType.parseModuleId(modulePath);
 
   assertEquals(result, "foo");
 });
 
 Deno.test("parseModuleId parses structured ids", () => {
-  const path = "/Users/foundations/f/platforms/p/foo/bar/terragrunt.hcl";
-  const result = PlatformModuleType.parseModuleId(path);
+  const modulePath = path.join(
+    "Users",
+    "foundations",
+    "f",
+    "platforms",
+    "p",
+    "foo",
+    "bar",
+    "terragrunt.hcl",
+  );
+
+  const result = PlatformModuleType.parseModuleId(modulePath);
 
   assertEquals(result, "foo/bar");
 });

--- a/src/commands/foundation/PlatformModuleType.ts
+++ b/src/commands/foundation/PlatformModuleType.ts
@@ -38,6 +38,6 @@ export class PlatformModuleType extends StringType {
       dropTerragruntHclComponent,
     );
 
-    return path.join(...moduleId);
+    return moduleId.join("/");
   }
 }

--- a/src/commands/foundation/PlatformModuleType.ts
+++ b/src/commands/foundation/PlatformModuleType.ts
@@ -2,22 +2,15 @@ import * as fs from "std/fs";
 import * as path from "std/path";
 import { StringType } from "x/cliffy/command";
 
+import { CollieRepository } from "../../model/CollieRepository.ts";
+
 export class PlatformModuleType extends StringType {
   async complete(): Promise<string[]> {
-    const modules = [];
-
-    for await (
-      const file of fs.expandGlob(
-        "foundations/*/platforms/*/**/terragrunt.hcl",
-        {
-          exclude: ["**/.terragrunt-cache"],
-          globstar: true,
-        },
-      )
-    ) {
-      const id = PlatformModuleType.parseModuleId(file.path);
-      modules.push(id);
-    }
+    const repo = await CollieRepository.load();
+    const modules = await repo.processFilesGlob(
+      "foundations/*/platforms/*/**/terragrunt.hcl",
+      (file) => PlatformModuleType.parseModuleId(file.path),
+    );
 
     // I don't know how we could get the foundation name passed to the arg to filter
     // only to the platforms in the already specified foundation

--- a/src/compliance/ComplianceControlParser.ts
+++ b/src/compliance/ComplianceControlParser.ts
@@ -21,26 +21,19 @@ export class ComplianceControlParser {
   ) {}
 
   public async load() {
-    const dir = this.repo.resolvePath("compliance");
-
     const progress = new ProgressReporter(
       "parsing",
       "compliance controls",
       this.logger,
     );
 
-    const q = [];
-    for await (
-      const file of fs.expandGlob("**/*.md", {
-        root: dir,
-        globstar: true,
-      })
-    ) {
-      const isControl = file.name !== "README.md"; // skip READMEs they're typically not controls but user-provided documentation
+    const q = await this.repo.processFilesGlob("compliance/**/*.md", (file) => {
+      // skip READMEs they're typically not controls but user-provided documentation
+      const isControl = file.name !== "README.md";
       if (isControl) {
-        q.push(this.parseComplianceControl(file.path));
+        return this.parseComplianceControl(file.path);
       }
-    }
+    });
 
     const modules = await Promise.all(q);
 

--- a/src/kit/KitModuleParser.test.ts
+++ b/src/kit/KitModuleParser.test.ts
@@ -67,13 +67,13 @@ markdown`,
 
     const expected = [
       {
-        definitionPath: "kit/valid/README.md",
+        definitionPath: path.join("kit", "valid", "README.md"),
         id: "valid",
         kitModule: {
           name: "test",
           summary: "it's cool",
         },
-        kitModulePath: "kit/valid",
+        kitModulePath: path.join("kit", "valid"),
         readme: "\n# some\nmarkdown",
       },
     ];

--- a/src/kit/KitModuleParser.test.ts
+++ b/src/kit/KitModuleParser.test.ts
@@ -1,0 +1,86 @@
+import { assertEquals } from "std/testing/assert";
+import * as path from "std/path";
+import { withTempDir } from "../cli/test-util.ts";
+import { Logger } from "../cli/Logger.ts";
+import {
+  Dir,
+  DirectoryGenerator,
+  WriteMode,
+} from "../cli/DirectoryGenerator.ts";
+import { KitModuleParser } from "./KitModuleParser.ts";
+import { ModelValidator } from "../model/schemas/ModelValidator.ts";
+import { CollieRepository } from "../model/CollieRepository.ts";
+
+Deno.test("integration test for load", async () => {
+  await withTempDir(async (tmp) => {
+    const stubRepo = CollieRepository.uninitialized(tmp);
+    const logger = new Logger(stubRepo, {});
+    const validator = new ModelValidator(logger);
+    const sut = new KitModuleParser(stubRepo, validator, logger);
+
+    const dir: Dir = {
+      name: path.join(tmp, "kit"),
+      entries: [
+        {
+          name: "README.md",
+          content: "ignore me",
+        },
+        {
+          name: ".terraform",
+          entries: [
+            {
+              name: "README.md",
+              content: "ignore me",
+            },
+          ],
+        },
+        {
+          name: "invalid",
+          entries: [
+            {
+              name: "README.md",
+              content: "not a proper kit module",
+            },
+          ],
+        },
+        {
+          name: "valid",
+          entries: [
+            {
+              name: "README.md",
+              content: `---
+name: test
+summary: it's cool
+---
+
+# some
+markdown`,
+            },
+          ],
+        },
+      ],
+    };
+
+    await new DirectoryGenerator(WriteMode.overwrite, logger).write(dir);
+
+    const result = await sut.load();
+
+    const expected = [
+      {
+        definitionPath: "kit/valid/README.md",
+        id: "valid",
+        kitModule: {
+          name: "test",
+          summary: "it's cool",
+        },
+        kitModulePath: "kit/valid",
+        readme: "\n# some\nmarkdown",
+      },
+    ];
+
+    assertEquals(
+      result.filter((x) => !!x),
+      expected,
+    );
+  });
+});

--- a/src/kit/KitModuleParser.ts
+++ b/src/kit/KitModuleParser.ts
@@ -20,29 +20,16 @@ export class KitModuleParser {
   ) {}
 
   public async load() {
-    const dir = this.repo.resolvePath("kit");
-
     const progress = new ProgressReporter(
       "parsing",
       "kit modules",
       this.logger,
     );
 
-    const q = [];
-    for await (
-      const file of fs.expandGlob("**/README.md", {
-        root: dir,
-        exclude: [
-          "README.md", // exclude top-level readme
-          "**/modules", // exclude sub-modules
-          "**/template", // exclude template files
-          "**/.terraform", // exclude terraform dot-files (these can be left in kit/ from e.g. calling terraform validate)
-        ],
-        globstar: true,
-      })
-    ) {
-      q.push(this.parseKitModule(file.path));
-    }
+    const q = await this.repo.processFilesGlob(
+      "kit/**/README.md",
+      (file) => this.parseKitModule(file.path),
+    );
 
     const modules = await Promise.all(q);
 


### PR DESCRIPTION
This PR fixes various small issues regarding consistently scanning files in the collie repository
- consistently handle ignores in various commands (see #230 for ideas) 
- fix windows behavior
- fix autocompletion bugs when running from subdir