### PR TITLE
feat: add validation to verify control and kit module ids in "new"

### DIFF
--- a/src/cli/validation.test.ts
+++ b/src/cli/validation.test.ts
@@ -1,0 +1,17 @@
+import { validateIsPrefixedId } from "./validation.ts";
+import { assertEquals } from "std/testing/assert";
+
+Deno.test("non-prefixed ids fail", () => {
+  const result = validateIsPrefixedId("abc");
+  assertEquals(result, false);
+});
+
+Deno.test("prefixed ids pass", () => {
+  const result = validateIsPrefixedId("abc/123");
+  assertEquals(result, true);
+});
+
+Deno.test("prefixed ids with paths pass", () => {
+  const result = validateIsPrefixedId("abc/123/xyz");
+  assertEquals(result, true);
+});

--- a/src/cli/validation.ts
+++ b/src/cli/validation.ts
@@ -1,0 +1,5 @@
+const prefixedId = /.+\/.+/g;
+
+export function validateIsPrefixedId(id: string) {
+  return prefixedId.test(id);
+}

--- a/src/cli/validation.ts
+++ b/src/cli/validation.ts
@@ -1,4 +1,4 @@
-const prefixedId = /.+\/.+/g;
+const prefixedId = /.+\/.+/;
 
 export function validateIsPrefixedId(id: string) {
   return prefixedId.test(id);

--- a/src/commands/kit/new.command.ts
+++ b/src/commands/kit/new.command.ts
@@ -4,13 +4,24 @@ import { CollieRepository } from "../../model/CollieRepository.ts";
 import { GlobalCommandOptions } from "../GlobalCommandOptions.ts";
 import { TopLevelCommand } from "../TopLevelCommand.ts";
 import { newKitDirectoryCreation } from "./kit-utilities.ts";
+import { ValidationError } from "x/cliffy/command";
+import { validateIsPrefixedId } from "../../cli/validation.ts";
+
+const idValidationMessage =
+  "Kit module ids must contain a prefix for a platform like 'platform/module'";
 
 export function registerNewCmd(program: TopLevelCommand) {
   program
     .command("new <module> [name]")
-    .description("Generate a new kit module terraform template")
+    .description(
+      `Generate a new kit module terraform template.\n${idValidationMessage}`,
+    )
     .action(
       async (opts: GlobalCommandOptions, module: string, name?: string) => {
+        if (!validateIsPrefixedId(module)) {
+          throw new ValidationError(idValidationMessage);
+        }
+
         const collie = await CollieRepository.load();
         const logger = new Logger(collie, opts);
 


### PR DESCRIPTION
collie's repository layout assumes the following pattern
- controls are prefixed framework/control
- kit modules are prefixed platform/module

this implicit assumption is in place for the "tree" commands and we think its a good convention for consistency

fixes #262 