### PR TITLE
feature/debug documentation update errors

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1,5 +1,50 @@
 {
-  "version": "2",
+  "version": "3",
+  "packages": {
+    "specifiers": {
+      "npm:ajv-formats@2.1.0": "npm:ajv-formats@2.1.0_ajv@8.12.0",
+      "npm:ajv@8.12.0": "npm:ajv@8.12.0"
+    },
+    "npm": {
+      "ajv-formats@2.1.0_ajv@8.12.0": {
+        "integrity": "sha512-USH2jBb+C/hIpwD2iRjp0pe0k+MvzG0mlSn/FIdCgQhUb9ALPRjt2KIQdfZDS9r0ZIeUAg7gOu9KL0PFqGqr5Q==",
+        "dependencies": {
+          "ajv": "ajv@8.12.0"
+        }
+      },
+      "ajv@8.12.0": {
+        "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+        "dependencies": {
+          "fast-deep-equal": "fast-deep-equal@3.1.3",
+          "json-schema-traverse": "json-schema-traverse@1.0.0",
+          "require-from-string": "require-from-string@2.0.2",
+          "uri-js": "uri-js@4.4.1"
+        }
+      },
+      "fast-deep-equal@3.1.3": {
+        "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+        "dependencies": {}
+      },
+      "json-schema-traverse@1.0.0": {
+        "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+        "dependencies": {}
+      },
+      "punycode@2.3.0": {
+        "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+        "dependencies": {}
+      },
+      "require-from-string@2.0.2": {
+        "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+        "dependencies": {}
+      },
+      "uri-js@4.4.1": {
+        "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+        "dependencies": {
+          "punycode": "punycode@2.3.0"
+        }
+      }
+    }
+  },
   "remote": {
     "https://cdn.esm.sh/v77/ajv-formats@2.1.0/deno/ajv-formats.js": "bfc5b929af623c70d65dc6f3e1e1301283a9183b488bc3852175e457bcb9ce2e",
     "https://cdn.esm.sh/v77/ajv-formats@2.1.0/dist/formats.d.ts": "c4592c3bec339a4cf9a4edd7c24d362798c31cc41558570c1e6f91a99aadc8ee",
@@ -244,6 +289,7 @@
     "https://deno.land/std@0.170.0/bytes/bytes_list.ts": "aba5e2369e77d426b10af1de0dcc4531acecec27f9b9056f4f7bfbf8ac147ab4",
     "https://deno.land/std@0.170.0/bytes/concat.ts": "97a1274e117510ffffc9499c4debb9541e408732bab2e0ca624869ae13103c10",
     "https://deno.land/std@0.170.0/bytes/copy.ts": "d14a58f188a997ee0d2ba696d0c82a42f4fb4b6705e90a4238b77d7644dae24c",
+    "https://deno.land/std@0.170.0/collections/chunk.ts": "10a147f3252406a011e0fa96a81a2e7e72cc79f9d15301e6de32424863a15f64",
     "https://deno.land/std@0.170.0/collections/distinct.ts": "278a5b36d7cbb2f8a25e09039064ac7894656e03d25860c58ac1735353fc2898",
     "https://deno.land/std@0.170.0/collections/group_by.ts": "ce8057c75d640491c0c81e0a6ce5524a8c0af00977a445ca5dbde24e4371d109",
     "https://deno.land/std@0.170.0/encoding/_yaml/dumper/dumper.ts": "5bd334372608a1aec7a2343705930889d4048f57a2c4d398f1d6d75996ecd0d3",
@@ -566,50 +612,5 @@
     "https://raw.githubusercontent.com/zongwei007/cli-format-deno/v3.x/src/format-config.ts": "ea3aba589931cb93c1e191747061fd1eecad06fb8a80c173b1e306c66a7ef2bf",
     "https://raw.githubusercontent.com/zongwei007/cli-format-deno/v3.x/src/format.ts": "bd3bd5bfc026d86f05967ba1a7edf12c9ddb05acbd03a7cdf92e794483646942",
     "https://raw.githubusercontent.com/zongwei007/cli-format-deno/v3.x/src/mod.ts": "c600d0e52aa06e41beade120a11971bc0a64e51edbbac12a7b1699a67d801c9c"
-  },
-  "npm": {
-    "specifiers": {
-      "ajv-formats@2.1.0": "ajv-formats@2.1.0_ajv@8.12.0",
-      "ajv@8.12.0": "ajv@8.12.0"
-    },
-    "packages": {
-      "ajv-formats@2.1.0_ajv@8.12.0": {
-        "integrity": "sha512-USH2jBb+C/hIpwD2iRjp0pe0k+MvzG0mlSn/FIdCgQhUb9ALPRjt2KIQdfZDS9r0ZIeUAg7gOu9KL0PFqGqr5Q==",
-        "dependencies": {
-          "ajv": "ajv@8.12.0"
-        }
-      },
-      "ajv@8.12.0": {
-        "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-        "dependencies": {
-          "fast-deep-equal": "fast-deep-equal@3.1.3",
-          "json-schema-traverse": "json-schema-traverse@1.0.0",
-          "require-from-string": "require-from-string@2.0.2",
-          "uri-js": "uri-js@4.4.1"
-        }
-      },
-      "fast-deep-equal@3.1.3": {
-        "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-        "dependencies": {}
-      },
-      "json-schema-traverse@1.0.0": {
-        "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-        "dependencies": {}
-      },
-      "punycode@2.3.0": {
-        "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
-        "dependencies": {}
-      },
-      "require-from-string@2.0.2": {
-        "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-        "dependencies": {}
-      },
-      "uri-js@4.4.1": {
-        "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-        "dependencies": {
-          "punycode": "punycode@2.3.0"
-        }
-      }
-    }
   }
 }

--- a/src/api/terragrunt/TerragruntCliFacade.ts
+++ b/src/api/terragrunt/TerragruntCliFacade.ts
@@ -122,4 +122,19 @@ export class TerragruntCliFacade {
       cwd,
     });
   }
+
+  async collectOutputs(cwd: string, outputName: string) {
+    const cmds = [
+      "terragrunt",
+      "run-all",
+      "output",
+      "-raw",
+      outputName,
+      "--terragrunt-non-interactive", // disable terragrunt's own prompts, e.g. at the start of a terragrunt run-all run
+    ];
+
+    return await this.quietRunner.run(cmds, {
+      cwd,
+    });
+  }
 }

--- a/src/api/terragrunt/TerragruntCliFacade.ts
+++ b/src/api/terragrunt/TerragruntCliFacade.ts
@@ -99,6 +99,16 @@ export class TerragruntCliFacade {
     });
   }
 
+  async moduleGroups(cwd: string): Promise<Record<string, string[]>> {
+    const cmds = ["terragrunt", "output-module-groups"];
+
+    const result = await this.quietRunner.run(cmds, {
+      cwd,
+    });
+
+    return JSON.parse(result.stdout);
+  }
+
   async collectOutput(cwd: string, outputName: string) {
     const cmds = [
       "terragrunt",

--- a/src/cli/Logger.ts
+++ b/src/cli/Logger.ts
@@ -63,8 +63,10 @@ export class Logger {
     console.error(colors.red(message));
   }
 
-  public tip(msg: string) {
-    printTip(msg);
+  public tip(msg: string | ((fmt: FormatUtils) => string)) {
+    const message = typeof msg === "string" ? msg : msg(this.fmtUtils);
+
+    printTip(message);
   }
 
   public tipCommand(msg: string, command: string) {

--- a/src/docs/PlatformDocumentationGenerator.ts
+++ b/src/docs/PlatformDocumentationGenerator.ts
@@ -1,5 +1,6 @@
 import * as fs from "std/fs";
 import * as path from "std/path";
+import { pooledMap } from "std/async";
 import { TerragruntCliFacade } from "../api/terragrunt/TerragruntCliFacade.ts";
 import { Logger } from "../cli/Logger.ts";
 import { ProgressReporter } from "../cli/ProgressReporter.ts";
@@ -75,7 +76,9 @@ export class PlatformDocumentationGenerator {
       this.logger,
     );
 
-    const tasks = dependencies.modules.map(
+    const iterator = await pooledMap(
+      1,
+      dependencies.modules,
       async (x) =>
         await this.generatePlatformModuleDocumentation(
           x,
@@ -84,7 +87,9 @@ export class PlatformDocumentationGenerator {
         ),
     );
 
-    await Promise.all(tasks);
+    for await (const _ of iterator) {
+      // consume iterator
+    }
 
     platformProgress.done();
   }

--- a/src/docs/PlatformDocumentationGenerator.ts
+++ b/src/docs/PlatformDocumentationGenerator.ts
@@ -87,22 +87,23 @@ export class PlatformDocumentationGenerator {
     this.logger.verbose(
       (_) =>
         `generating documentation will process the following groups: ${
-          JSON.stringify(groups, null, 2)
+          JSON.stringify(
+            groups,
+            null,
+            2,
+          )
         }`,
     );
 
     for (const group of Object.values(groups)) {
-      // within one group, we can run concurrent terragrunt invocations
-      const tasks = group.map(
-        async (platformModulePath) =>
-          await this.generatePlatformModuleDocumentation(
-            findDependency(dependencies, platformModulePath),
-            docsRepo,
-            dependencies.platform,
-          ),
-      );
-
-      await Promise.all(tasks);
+      // within one group, we still have to go serially
+      for (const platformModulePath of group) {
+        await this.generatePlatformModuleDocumentation(
+          findDependency(dependencies, platformModulePath),
+          docsRepo,
+          dependencies.platform,
+        );
+      }
     }
 
     platformProgress.done();

--- a/src/docs/PlatformDocumentationGenerator.ts
+++ b/src/docs/PlatformDocumentationGenerator.ts
@@ -1,6 +1,5 @@
 import * as fs from "std/fs";
 import * as path from "std/path";
-import { pooledMap } from "std/async";
 import { TerragruntCliFacade } from "../api/terragrunt/TerragruntCliFacade.ts";
 import { Logger } from "../cli/Logger.ts";
 import { ProgressReporter } from "../cli/ProgressReporter.ts";

--- a/src/docs/PlatformDocumentationGenerator.ts
+++ b/src/docs/PlatformDocumentationGenerator.ts
@@ -229,7 +229,7 @@ function findDependency(
 ): KitModuleDependency {
   const dependency = dependencies.modules.find((dep) => {
     const relativePlatformModuleDir = path.dirname(dep.sourcePath);
-    platformModulePath.endsWith(relativePlatformModuleDir);
+    return platformModulePath.endsWith(relativePlatformModuleDir);
   });
 
   if (!dependency) {

--- a/src/docs/PlatformModuleOutputCollector.test.ts
+++ b/src/docs/PlatformModuleOutputCollector.test.ts
@@ -1,0 +1,21 @@
+import { assertEquals } from "std/testing/assert";
+import { RunAllPlatformModuleOutputCollector } from "./PlatformModuleOutputCollector.ts";
+
+const stdout = `
+--- BEGIN COLLIE PLATFORM MODULE OUTPUT: logging ---
+foo
+123
+--- BEGIN COLLIE PLATFORM MODULE OUTPUT: billing ---
+bar
+xyz`;
+
+Deno.test("can split", () => {
+  const result = RunAllPlatformModuleOutputCollector.parseTerragrunt(stdout);
+
+  const expected = [
+    { module: "logging", output: "foo\n123" },
+    { module: "billing", output: "bar\nxyz" },
+  ];
+
+  assertEquals(result, expected);
+});

--- a/src/docs/PlatformModuleOutputCollector.ts
+++ b/src/docs/PlatformModuleOutputCollector.ts
@@ -1,0 +1,117 @@
+import * as path from "std/path";
+import { chunk } from "std/collections/chunk";
+import { TerragruntCliFacade } from "../api/terragrunt/TerragruntCliFacade.ts";
+import { KitModuleDependency } from "../kit/KitDependencyAnalyzer.ts";
+import { CollieRepository } from "../model/CollieRepository.ts";
+import { Logger } from "../cli/Logger.ts";
+import { MeshError } from "../errors.ts";
+
+export interface PlatformModuleOutputCollector {
+  getOutput(dep: KitModuleDependency): Promise<string>;
+}
+
+interface PlatformModuleOutput {
+  module: string;
+  output: string;
+}
+
+export class RunAllPlatformModuleOutputCollector
+  implements PlatformModuleOutputCollector {
+  private modules: PlatformModuleOutput[] = [];
+
+  constructor(
+    private readonly terragrunt: TerragruntCliFacade,
+    private readonly logger: Logger,
+  ) {}
+
+  async initialize(platformPath: string) {
+    const result = await this.terragrunt.collectOutputs(
+      platformPath,
+      "documentation_md",
+    );
+
+    if (!result.status.success) {
+      this.logger.error(
+        (fmt) =>
+          `Failed to collect output "documentation_md" from platform ${
+            fmt.kitPath(
+              platformPath,
+            )
+          }`,
+      );
+      this.logger.error(result.stderr);
+
+      throw new MeshError(
+        "Failed to collect documentation output from platform modules",
+      );
+    }
+
+    this.modules = RunAllPlatformModuleOutputCollector.parseTerragrunt(
+      result.stdout,
+    );
+  }
+
+  // deno-lint-ignore require-await
+  async getOutput(dep: KitModuleDependency): Promise<string> {
+    const platformModulePath = path.dirname(dep.sourcePath);
+    const module = this.modules.find((x) =>
+      platformModulePath.endsWith(x.module)
+    );
+
+    if (!module) {
+      throw new MeshError(
+        "Failed to find documentation output from platform module " +
+          platformModulePath,
+      );
+    }
+    return module?.output;
+  }
+
+  public static parseTerragrunt(stdout: string): PlatformModuleOutput[] {
+    const regex = /^--- BEGIN COLLIE PLATFORM MODULE OUTPUT: (.+) ---$/gm;
+
+    const sections = stdout.split(regex);
+    const cleanedSections = sections
+      .map((x) => x.trim())
+      .filter((x) => x !== "");
+
+    return chunk(cleanedSections, 2).map(([module, output]) => ({
+      module,
+      output,
+    }));
+  }
+}
+
+export class RunIndividualPlatformModuleOutputCollector
+  implements PlatformModuleOutputCollector {
+  constructor(
+    private readonly repo: CollieRepository,
+    private readonly terragrunt: TerragruntCliFacade,
+    private readonly logger: Logger,
+  ) {}
+
+  async getOutput(dep: KitModuleDependency): Promise<string> {
+    const result = await this.terragrunt.collectOutput(
+      this.repo.resolvePath(path.dirname(dep.sourcePath)),
+      "documentation_md",
+    );
+
+    if (!result.status.success) {
+      this.logger.error(
+        (fmt) =>
+          `Failed to collect output "documentation_md" from platform module ${
+            fmt.kitPath(
+              dep.sourcePath,
+            )
+          }`,
+      );
+      this.logger.error(result.stderr);
+
+      throw new MeshError(
+        "Failed to collect documentation output from platform modules",
+      );
+    }
+
+    return result.stdout;
+  }
+}

--- a/src/import_map.json
+++ b/src/import_map.json
@@ -8,6 +8,7 @@
     "std/archive/tar": "https://deno.land/std@0.170.0/archive/tar.ts",
     "std/archive/untar": "https://deno.land/std@0.170.0/archive/untar.ts",
     "std/streams/conversion": "https://deno.land/std@0.170.0/streams/conversion.ts",
+    "std/collections/chunk": "https://deno.land/std@0.170.0/collections/chunk.ts",
     "std/collections/groupBy": "https://deno.land/std@0.170.0/collections/group_by.ts",
     "std/collections/distinct": "https://deno.land/std@0.170.0/collections/distinct.ts",
     "std/fmt/colors": "https://deno.land/std@0.170.0/fmt/colors.ts",


### PR DESCRIPTION
This PR fixes #265 

It adds a new and faster way to collect documentation outputs from modules. This support however requires a terragrunt before_hook in `platform.hcl` files. A fallback is in place for producing documentation correctly with a slower, but safe alternative method.

After quite a bit of testing, I determined the following

- terragrunt appears to have built-in magic support for gcs backends and thus this issue occurs less when on gcs vs using azure storage containers
- the only safe way to execute terragrunt in our platform stacks is to execute via terragrunt run-all or one terragrunt command at a time
