### PR TITLE
feature: add tenant modules to docs wip

### DIFF
--- a/src/docs/PlatformDocumentationGenerator.ts
+++ b/src/docs/PlatformDocumentationGenerator.ts
@@ -9,7 +9,6 @@ import {
   PlatformDependencies,
 } from "../kit/KitDependencyAnalyzer.ts";
 import { CollieRepository } from "../model/CollieRepository.ts";
-
 import { FoundationRepository } from "../model/FoundationRepository.ts";
 import { PlatformConfig } from "../model/PlatformConfig.ts";
 import { DocumentationRepository } from "./DocumentationRepository.ts";
@@ -197,7 +196,12 @@ export class PlatformDocumentationGenerator {
     docsRepo: DocumentationRepository,
     destPath: string,
   ) {
-    if (!dep.kitModule) {
+    if (dep.kitModuleId == "tenant") {
+      const kitModuleSection = `::: tip Tenant module
+This is a tenant module.
+:::`;
+      return kitModuleSection;
+    } else if (!dep.kitModule) {
       return MarkdownUtils.container(
         "warning",
         "Invalid Kit Module Dependency",

--- a/src/kit/KitDependencyAnalyzer.ts
+++ b/src/kit/KitDependencyAnalyzer.ts
@@ -102,17 +102,25 @@ export class KitDependencyAnalyzer {
     );
     const kitModule = this.kitModules.tryFindById(kitModuleId);
 
-    if (!kitModule) {
+    if (kitModuleId.includes("/tenants/")) {
+      return {
+        sourcePath,
+        kitModuleId: "tenant",
+        kitModulePath: sourcePath.replace("/terragrunt.hcl", ""),
+        kitModule,
+      };
+    } else if (!kitModule) {
       const msg =
         `Could not find kit module with id ${kitModuleId} included from ${sourcePath}`;
       this.logger.warn(msg);
+    } else {
+      return {
+        sourcePath,
+        kitModuleId,
+        kitModulePath,
+        kitModule,
+      };
     }
-    return {
-      sourcePath,
-      kitModuleId,
-      kitModulePath,
-      kitModule,
-    };
   }
 
   static parseTerraformSource(hcl: string): string | undefined {


### PR DESCRIPTION
I actually wanted to have a sub folder in which the tenants are located. But that's beyond my abilities :( but maybe its enough as a small improvement for having the Tenants in the Documentation without any Error message because of the missing kit.