### PR TITLE
chore: adding expose=true collie kit apply

### DIFF
--- a/src/commands/kit/kit-utilities.ts
+++ b/src/commands/kit/kit-utilities.ts
@@ -89,6 +89,7 @@ export async function generateTerragrunt(
 
   const platformIncludeBlock = `include "platform" {
   path = find_in_parent_folders("platform.hcl")
+  expose = true
 }`;
 
   const providerBlock =


### PR DESCRIPTION
thats missing if you would use it with our workflow and its also part of all our terragrunt.hcl in the kits