### PR TITLE
feature/drop unstable

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,8 @@
-{ pkgs ? import <nixpkgs> { }, unstable ? import <nixpkgs-unstable> { } }:
+{ pkgs ? import <nixpkgs> { }
+, unstable ? import <nixpkgs-unstable> {
+    config.allowUnfree = true;
+  }
+}:
 
 pkgs.mkShell {
   NIX_SHELL = "collie-cli";
@@ -7,8 +11,8 @@ pkgs.mkShell {
   '';
 
   buildInputs = [
-    unstable.deno
-    
+    pkgs.deno
+
     # used for build scripts
     pkgs.unzip
     pkgs.gnused
@@ -19,10 +23,10 @@ pkgs.mkShell {
     pkgs.google-cloud-sdk
 
     # terraform
-    unstable.terraform
-    unstable.terragrunt
-    unstable.tflint
-    unstable.terraform-docs
+    pkgs.terraform
+    pkgs.terragrunt
+    pkgs.tflint
+    pkgs.terraform-docs
 
     # for collie foundation docs
     pkgs.nodejs

--- a/src/info.ts
+++ b/src/info.ts
@@ -2,7 +2,7 @@
 
 // ATTENTION: DO NOT COMMIT CHANGES TO THIS VERSION STRING, it's replaced in build.sh when performing a release.
 // This should always have the value "v0.22.0"
-export const VERSION = "vDEVELOPMENT".substring(1);
+export const VERSION = "v0.24.0-2-g3f740f9".substring(1);
 
 /**
  * The flags we want collie to be invoked with.
@@ -11,7 +11,7 @@ export const VERSION = "vDEVELOPMENT".substring(1);
  * see https://deno.com/blog/v1.21#deno-check-and-the-path-to-not-type-checking-by-default
  */
 export const FLAGS =
-  `--unstable --allow-read --allow-write --allow-env --allow-run --allow-net --no-check`;
+  `--allow-read --allow-write --allow-env --allow-run --allow-net --no-check`;
 export const GITHUB_REPO = "meshcloud/collie-cli";
 
 // Use the CLI Command when mentioning it as a command to run, e.g.: Please run "${CLI} -h" to see more.


### PR DESCRIPTION
- chore: drop invoking deno with the --unstable flag
- chore: use stable nixpkgs in nix shell
