### PR TITLE
features/test command

### DIFF
--- a/src/api/terragrunt/TerragruntCliFacade.ts
+++ b/src/api/terragrunt/TerragruntCliFacade.ts
@@ -11,6 +11,7 @@ export type TerragruntArguments = {
 };
 
 export interface TerragruntRunAllOpts {
+  includeDirs?: string[];
   excludeDirs?: string[];
   autoApprove?: boolean;
 }
@@ -72,6 +73,15 @@ export class TerragruntCliFacade {
       .concat([workaroundTerragruntOnWindowsScanningItsOwnCaches])
       .flatMap((x) => ["--terragrunt-exclude-dir", x]);
 
+    const includeDirFlags = (opts.includeDirs || []).flatMap((
+      x,
+    ) => ["--terragrunt-include-dir", x]);
+
+    // if we have explicit includes, turn on strict mode so that only includesd files will run
+    if (includeDirFlags.length) {
+      includeDirFlags.push("--terragrunt-strict-include");
+    }
+
     // By default, "terragrunt run-all" auto approves all individual applies, a notable difference to "terragrunt run"
     // which does interactive confirmation prompts by default.
     // This is undesirable for collie beause it unexpectedly changes the behavior when running a single vs. multi-module
@@ -87,6 +97,7 @@ export class TerragruntCliFacade {
       "terragrunt",
       "run-all",
       ...mode.raw,
+      ...includeDirFlags,
       ...excludeDirFlags,
       ...autoApproveFlags,
     ];

--- a/src/api/terragrunt/TerragruntCliFacade.ts
+++ b/src/api/terragrunt/TerragruntCliFacade.ts
@@ -110,34 +110,9 @@ export class TerragruntCliFacade {
     });
   }
 
-  async moduleGroups(cwd: string): Promise<Record<string, string[]>> {
-    const cmds = ["terragrunt", "output-module-groups"];
-
-    const result = await this.quietRunner.run(cmds, {
-      cwd,
-    });
-
-    return JSON.parse(result.stdout);
-  }
-
   async collectOutput(cwd: string, outputName: string) {
     const cmds = [
       "terragrunt",
-      "output",
-      "-raw",
-      outputName,
-      "--terragrunt-non-interactive", // disable terragrunt's own prompts, e.g. at the start of a terragrunt run-all run
-    ];
-
-    return await this.quietRunner.run(cmds, {
-      cwd,
-    });
-  }
-
-  async collectOutputs(cwd: string, outputName: string) {
-    const cmds = [
-      "terragrunt",
-      "run-all",
       "output",
       "-raw",
       outputName,

--- a/src/cli/NullProgressReporter.ts
+++ b/src/cli/NullProgressReporter.ts
@@ -1,0 +1,7 @@
+/**
+ * A null object that allows us to skip reporting for foundation/platform progress when those are not needed
+ */
+
+export class NullProgressReporter {
+  done(): void {}
+}

--- a/src/commands/foundation/TestModuleType.ts
+++ b/src/commands/foundation/TestModuleType.ts
@@ -6,10 +6,15 @@ import { PlatformModuleType } from "./PlatformModuleType.ts";
 export class TestModuleType extends StringType {
   async complete(): Promise<string[]> {
     const repo = await CollieRepository.load();
+    const excludes = {
+      testModules: false,
+      tenantModules: true,
+    };
+
     const modules = await repo.processFilesGlob(
       "foundations/*/platforms/**/*.test/terragrunt.hcl",
       (file) => PlatformModuleType.parseModuleId(file.path),
-      false,
+      excludes,
     );
 
     // I don't know how we could get the foundation name passed to the arg to filter

--- a/src/commands/foundation/TestModuleType.ts
+++ b/src/commands/foundation/TestModuleType.ts
@@ -1,0 +1,21 @@
+import { StringType } from "x/cliffy/command";
+
+import { CollieRepository } from "../../model/CollieRepository.ts";
+import { PlatformModuleType } from "./PlatformModuleType.ts";
+
+export class TestModuleType extends StringType {
+  async complete(): Promise<string[]> {
+    const repo = await CollieRepository.load();
+    const modules = await repo.processFilesGlob(
+      "foundations/*/platforms/**/*.test/terragrunt.hcl",
+      (file) => PlatformModuleType.parseModuleId(file.path),
+      false,
+    );
+
+    // I don't know how we could get the foundation name passed to the arg to filter
+    // only to the platforms in the already specified foundation
+    // the foundation arg seems not passed to the completions command, so there's nothing we can do here
+
+    return modules;
+  }
+}

--- a/src/commands/foundation/foundation.command.ts
+++ b/src/commands/foundation/foundation.command.ts
@@ -1,4 +1,5 @@
 import { registerDeployCmd } from "./deploy.command.ts";
+import { registerTestCmd } from "./test.command.ts";
 import { registerConfigCmd } from "./config.command.ts";
 import { registerNewCmd } from "./new.command.ts";
 import { registerTreeCmd } from "./tree.command.ts";
@@ -11,6 +12,7 @@ export function registerFoundationCommand(program: TopLevelCommand) {
   registerConfigCmd(foundationCommands);
   registerTreeCmd(foundationCommands);
   registerDeployCmd(foundationCommands);
+  registerTestCmd(foundationCommands);
   registerDocsCmd(foundationCommands);
 
   program

--- a/src/commands/foundation/test.command.ts
+++ b/src/commands/foundation/test.command.ts
@@ -1,0 +1,121 @@
+import {
+  TerragruntArguments,
+  toVerb,
+} from "/api/terragrunt/TerragruntCliFacade.ts";
+
+import { GlobalCommandOptions } from "../GlobalCommandOptions.ts";
+import { CollieRepository } from "../../model/CollieRepository.ts";
+import { Logger } from "../../cli/Logger.ts";
+import { FoundationRepository } from "../../model/FoundationRepository.ts";
+import { ProgressReporter } from "../../cli/ProgressReporter.ts";
+import { ModelValidator } from "../../model/schemas/ModelValidator.ts";
+import { CliApiFacadeFactory } from "../../api/CliApiFacadeFactory.ts";
+import { PlatformDeployer } from "../../foundation/PlatformDeployer.ts";
+import { PlatformModuleType } from "./PlatformModuleType.ts";
+import { CLI } from "../../info.ts";
+import { LiteralArgsParser } from "../LiteralArgsParser.ts";
+import { TopLevelCommand } from "../TopLevelCommand.ts";
+import { getCurrentWorkingFoundation } from "../../cli/commandOptionsConventions.ts";
+import { findPlatforms } from "./deploy.command.ts";
+import { NullProgressReporter } from "../../cli/NullProgressReporter.ts";
+
+interface TestOptions {
+  platform?: string;
+  module?: string;
+}
+
+export function registerTestCmd(program: TopLevelCommand) {
+  const cmd = program
+    .command("test [foundation:foundation]")
+    .description(
+      "Run platform test modules in your cloud foundations using terragrunt",
+    )
+    .type("module", new PlatformModuleType())
+    .option(
+      "-p, --platform <platform:platform>", // todo: make optional -> deploy all platforms!
+      "the platform to test",
+    )
+    .option("--module <module:module>", "Execute this specific test module")
+    .option(
+      "-- [args...]",
+      "pass the following raw arguments to terragrunt instead of running the default 'test'.",
+    )
+    .example(
+      "Run terraform test on all test modules",
+      `${CLI} foundation test myfoundation`,
+    )
+    .example(
+      "Run terraform plan on all modules of a platform",
+      `${CLI} foundation test myfoundation --platform aws`,
+    )
+    .example(
+      "Update terraform modules and providers",
+      `${CLI} foundation test myfoundation --platform aws --module connectivity.test -- init -upgrade`,
+    )
+    .action(
+      async (
+        opts: TestOptions & GlobalCommandOptions,
+        foundationArg: string | undefined,
+      ) => {
+        const literalArgs = LiteralArgsParser.parse(cmd.getRawArgs());
+
+        const collieRepo = await CollieRepository.load();
+        const logger = new Logger(collieRepo, opts);
+        const validator = new ModelValidator(logger);
+
+        const mode = { raw: literalArgs.length ? literalArgs : ["test"] };
+
+        const foundation = await getCurrentWorkingFoundation(
+          foundationArg,
+          logger,
+          collieRepo,
+        );
+
+        const foundationProgress = opts.platform
+          ? new NullProgressReporter()
+          : new ProgressReporter(
+            toVerb(mode),
+            collieRepo.relativePath(
+              collieRepo.resolvePath("foundations", foundation),
+            ),
+            logger,
+          );
+
+        const foundationRepo = await FoundationRepository.load(
+          collieRepo,
+          foundation,
+          validator,
+        );
+
+        await testFoundation(collieRepo, foundationRepo, mode, opts, logger);
+
+        foundationProgress.done();
+      },
+    );
+}
+
+export async function testFoundation(
+  repo: CollieRepository,
+  foundation: FoundationRepository,
+  mode: TerragruntArguments,
+  opts: GlobalCommandOptions & TestOptions,
+  logger: Logger,
+) {
+  const factory = new CliApiFacadeFactory(logger);
+
+  const terragrunt = factory.buildTerragrunt();
+
+  const platforms = findPlatforms(opts.platform, foundation, logger);
+
+  for (const platform of platforms) {
+    const deployer = new PlatformDeployer(
+      platform,
+      repo,
+      foundation,
+      terragrunt,
+      logger,
+    );
+
+    await deployer.runTestModules(mode, opts.module);
+  }
+}

--- a/src/commands/foundation/test.command.ts
+++ b/src/commands/foundation/test.command.ts
@@ -11,13 +11,13 @@ import { ProgressReporter } from "../../cli/ProgressReporter.ts";
 import { ModelValidator } from "../../model/schemas/ModelValidator.ts";
 import { CliApiFacadeFactory } from "../../api/CliApiFacadeFactory.ts";
 import { PlatformDeployer } from "../../foundation/PlatformDeployer.ts";
-import { PlatformModuleType } from "./PlatformModuleType.ts";
 import { CLI } from "../../info.ts";
 import { LiteralArgsParser } from "../LiteralArgsParser.ts";
 import { TopLevelCommand } from "../TopLevelCommand.ts";
 import { getCurrentWorkingFoundation } from "../../cli/commandOptionsConventions.ts";
 import { findPlatforms } from "./deploy.command.ts";
 import { NullProgressReporter } from "../../cli/NullProgressReporter.ts";
+import { TestModuleType } from "./TestModuleType.ts";
 
 interface TestOptions {
   platform?: string;
@@ -30,7 +30,7 @@ export function registerTestCmd(program: TopLevelCommand) {
     .description(
       "Run platform test modules in your cloud foundations using terragrunt",
     )
-    .type("module", new PlatformModuleType())
+    .type("module", new TestModuleType())
     .option(
       "-p, --platform <platform:platform>", // todo: make optional -> deploy all platforms!
       "the platform to test",

--- a/src/foundation/PlatformDeployer.ts
+++ b/src/foundation/PlatformDeployer.ts
@@ -170,10 +170,15 @@ export class PlatformDeployer<T extends PlatformConfig> {
   }
 
   private async testModuleTerragruntFiles(relativeModulePath: string) {
+    const excludes = {
+      testModules: false,
+      tenantModules: true,
+    };
+
     const files = await this.repo.processFilesGlob(
       `${relativeModulePath}/${TEST_MODULE_GLOB}/terragrunt.hcl`,
       (file) => file,
-      false,
+      excludes,
     );
 
     // a terragrunt stack conists of multiple executable terragrunt files

--- a/src/foundation/PlatformDeployer.ts
+++ b/src/foundation/PlatformDeployer.ts
@@ -9,9 +9,7 @@ import { FoundationRepository } from "/model/FoundationRepository.ts";
 import { PlatformConfig } from "/model/PlatformConfig.ts";
 import { Logger } from "../cli/Logger.ts";
 import { ProgressReporter } from "/cli/ProgressReporter.ts";
-import { CollieRepository } from "/model/CollieRepository.ts";
-
-const TEST_MODULE_GLOB = "**/*.test";
+import { CollieRepository, TEST_MODULE_GLOB } from "/model/CollieRepository.ts";
 
 export class PlatformDeployer<T extends PlatformConfig> {
   constructor(
@@ -67,9 +65,7 @@ export class PlatformDeployer<T extends PlatformConfig> {
       this.logger.warn(
         (fmt) =>
           `detected no platform modules at ${
-            fmt.kitPath(
-              platformOrModulePath,
-            )
+            fmt.kitPath(platformOrModulePath)
           }, will skip invoking "terragrunt <cmd>"`,
       );
 
@@ -85,9 +81,7 @@ export class PlatformDeployer<T extends PlatformConfig> {
       this.logger.debug(
         (fmt) =>
           `detected a single platform module at ${
-            fmt.kitPath(
-              singleModulePath,
-            )
+            fmt.kitPath(singleModulePath)
           }, will deploy with "terragrunt <cmd>"`,
       );
       await this.terragrunt.run(singleModulePath, mode, { autoApprove });
@@ -114,7 +108,6 @@ export class PlatformDeployer<T extends PlatformConfig> {
     const files = await this.repo.processFilesGlob(
       `${relativeModulePath}/**/terragrunt.hcl`,
       (file) => file,
-      [`foundations/${TEST_MODULE_GLOB}`],
     );
 
     // a terragrunt stack conists of multiple executable terragrunt files
@@ -143,9 +136,7 @@ export class PlatformDeployer<T extends PlatformConfig> {
       this.logger.warn(
         (fmt) =>
           `detected no test modules at ${
-            fmt.kitPath(
-              platformOrModulePath,
-            )
+            fmt.kitPath(platformOrModulePath)
           }, will skip invoking "terragrunt <cmd>"`,
       );
     } else if (tgfiles.length === 1) {
@@ -156,9 +147,7 @@ export class PlatformDeployer<T extends PlatformConfig> {
       this.logger.debug(
         (fmt) =>
           `detected a single test module at ${
-            fmt.kitPath(
-              singleModulePath,
-            )
+            fmt.kitPath(singleModulePath)
           }, will deploy with "terragrunt <cmd>"`,
       );
       await this.terragrunt.run(singleModulePath, mode, {});
@@ -184,6 +173,7 @@ export class PlatformDeployer<T extends PlatformConfig> {
     const files = await this.repo.processFilesGlob(
       `${relativeModulePath}/${TEST_MODULE_GLOB}/terragrunt.hcl`,
       (file) => file,
+      false,
     );
 
     // a terragrunt stack conists of multiple executable terragrunt files

--- a/src/kit/KitDependencyAnalyzer.ts
+++ b/src/kit/KitDependencyAnalyzer.ts
@@ -61,9 +61,14 @@ export class KitDependencyAnalyzer {
         this.logger,
       );
 
+      const excludes = {
+        tenantModules: true,
+        testModules: true,
+      };
       const q = await this.collie.processFilesGlob(
         `${relativePlatformPath}/**/terragrunt.hcl`,
         (file) => this.tryParseDependency(file.path),
+        excludes,
       );
 
       const all = await Promise.all(q);

--- a/src/model/CollieRepository.test.ts
+++ b/src/model/CollieRepository.test.ts
@@ -14,3 +14,10 @@ Deno.test("relativePath does not work with paths that are already relative", () 
   const result = sut.relativePath("123");
   assertNotEquals(result, "123");
 });
+
+Deno.test("resolvePath works", () => {
+  const sut = CollieRepository.uninitialized("/tmp/test");
+
+  const result = sut.resolvePath("123");
+  assertEquals(result, "/tmp/test/123");
+});

--- a/src/model/CollieRepository.test.ts
+++ b/src/model/CollieRepository.test.ts
@@ -1,5 +1,6 @@
 import { assertEquals, assertNotEquals } from "std/assert";
 import { CollieRepository } from "./CollieRepository.ts";
+import { isWindows } from "../os.ts";
 
 Deno.test("relativePath calculates paths relative to repository root", () => {
   const sut = CollieRepository.uninitialized("/tmp/test");
@@ -19,5 +20,8 @@ Deno.test("resolvePath works", () => {
   const sut = CollieRepository.uninitialized("/tmp/test");
 
   const result = sut.resolvePath("123");
-  assertEquals(result, "/tmp/test/123");
+
+  if (!isWindows) {
+    assertEquals(result, "/tmp/test/123");
+  }
 });

--- a/src/model/CollieRepository.ts
+++ b/src/model/CollieRepository.ts
@@ -1,6 +1,8 @@
 import * as fs from "std/fs";
 import * as path from "std/path";
 
+export const TEST_MODULE_GLOB = "**/*.test";
+
 export class CollieRepository {
   private constructor(private readonly repoDir: string) {
     if (!path.isAbsolute(repoDir)) {
@@ -50,7 +52,7 @@ export class CollieRepository {
   async processFilesGlob<T>(
     pattern: string,
     process: (file: fs.WalkEntry) => T | undefined,
-    additionalExcludes: string[] = [],
+    excludeTestModules = true,
   ): Promise<T[]> {
     const q: T[] = [];
     for await (
@@ -68,7 +70,7 @@ export class CollieRepository {
           "kit/**/modules", // exclude sub-modules
           "kit/**/template", // exclude template files
 
-          ...additionalExcludes,
+          ...(excludeTestModules ? [TEST_MODULE_GLOB] : []),
         ],
       })
     ) {

--- a/src/model/CollieRepository.ts
+++ b/src/model/CollieRepository.ts
@@ -2,6 +2,7 @@ import * as fs from "std/fs";
 import * as path from "std/path";
 
 export const TEST_MODULE_GLOB = "**/*.test";
+export const TENANT_MODULE_GLOB = "**/tenants";
 
 export class CollieRepository {
   private constructor(private readonly repoDir: string) {
@@ -52,7 +53,13 @@ export class CollieRepository {
   async processFilesGlob<T>(
     pattern: string,
     process: (file: fs.WalkEntry) => T | undefined,
-    excludeTestModules = true,
+    excludes: {
+      testModules: boolean;
+      tenantModules: boolean;
+    } = {
+      testModules: true,
+      tenantModules: false,
+    },
   ): Promise<T[]> {
     const q: T[] = [];
     for await (
@@ -70,7 +77,8 @@ export class CollieRepository {
           "kit/**/modules", // exclude sub-modules
           "kit/**/template", // exclude template files
 
-          ...(excludeTestModules ? [TEST_MODULE_GLOB] : []),
+          ...(excludes.testModules ? [TEST_MODULE_GLOB] : []),
+          ...(excludes.tenantModules ? [TENANT_MODULE_GLOB] : []),
         ],
       })
     ) {

--- a/src/model/CollieRepository.ts
+++ b/src/model/CollieRepository.ts
@@ -50,6 +50,7 @@ export class CollieRepository {
   async processFilesGlob<T>(
     pattern: string,
     process: (file: fs.WalkEntry) => T | undefined,
+    additionalExcludes: string[] = [],
   ): Promise<T[]> {
     const q: T[] = [];
     for await (
@@ -66,6 +67,8 @@ export class CollieRepository {
           "**/.terraform", // exclude terraform dot-files (these can be left in kit/ from e.g. calling terraform validate)
           "kit/**/modules", // exclude sub-modules
           "kit/**/template", // exclude template files
+
+          ...additionalExcludes,
         ],
       })
     ) {


### PR DESCRIPTION
The "collie foundation test" command executes `terraform test` (via terragrunt, as usual) on "test modules". By convention, these modules live next to platform modules and are named `*.test`.

This pattern is very useful to have dedicated modules that run tests against a landing zone architecture. One common use case is testing building blocks, as can be seen in the public https://github.com/likvid-bank/likvid-cloudfoundation reference implementation.