### PR TITLE
fix: "detected no test modules" error in "foundation test --module"

### DIFF
--- a/src/foundation/PlatformDeployer.ts
+++ b/src/foundation/PlatformDeployer.ts
@@ -175,8 +175,13 @@ export class PlatformDeployer<T extends PlatformConfig> {
       tenantModules: true,
     };
 
+    // if we specifiy a single module and not a prefix path, pick a single file
+    const glob = relativeModulePath.endsWith(".test")
+      ? `${relativeModulePath}/terragrunt.hcl`
+      : `${relativeModulePath}/${TEST_MODULE_GLOB}/terragrunt.hcl`;
+
     const files = await this.repo.processFilesGlob(
-      `${relativeModulePath}/${TEST_MODULE_GLOB}/terragrunt.hcl`,
+      glob,
       (file) => file,
       excludes,
     );


### PR DESCRIPTION
the previous implementation had a bug where setting the --module
flag would subsequently not find the module to invoke
